### PR TITLE
Enable mixed type arithmetic

### DIFF
--- a/include/boost/decimal.hpp
+++ b/include/boost/decimal.hpp
@@ -6,5 +6,6 @@
 #define BOOST_DECIMAL_HPP
 
 #include <boost/decimal/fwd.hpp>
+#include <boost/decimal/common_math.hpp>
 
 #endif //BOOST_DECIMAL_HPP

--- a/include/boost/decimal/common_math.hpp
+++ b/include/boost/decimal/common_math.hpp
@@ -1,0 +1,68 @@
+// Copyright 2023 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_COMMON_MATH_HPP
+#define BOOST_DECIMAL_COMMON_MATH_HPP
+
+#include <boost/decimal/detail/type_traits.hpp>
+#include <boost/decimal/decimal32.hpp>
+#include <type_traits>
+
+namespace boost { namespace decimal {
+
+// Overloads may be any integral type or,
+// TODO(mborland): any decimal type returning the promoted decimal type (e.g. dec32 + dec64 yields dec64)
+
+// Decimal32 overloads
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator+(decimal32 lhs, T rhs) noexcept
+{
+    return lhs + static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator+(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) + rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator-(decimal32 lhs, T rhs) noexcept
+{
+    return lhs - static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator-(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) - rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator*(decimal32 lhs, T rhs) noexcept
+{
+    return lhs * static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator*(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) * rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator/(decimal32 lhs, T rhs) noexcept
+{
+    return lhs / static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr decimal32 operator/(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) / rhs;
+}
+
+}}
+
+#endif // BOOST_DECIMAL_COMMON_MATH_HPP

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -209,22 +209,27 @@ public:
 
     // 3.2.8 binary arithmetic operators:
     friend constexpr decimal32 operator+(decimal32 lhs, decimal32 rhs) noexcept;
-    constexpr decimal32& operator++() noexcept;
-    constexpr decimal32 operator++(int) noexcept; // NOLINT : C++14 so constexpr implies const
-    constexpr decimal32& operator+=(decimal32 rhs) noexcept;
 
     friend constexpr decimal32 operator-(decimal32 lhs, decimal32 rhs) noexcept;
-    constexpr decimal32& operator--() noexcept;
-    constexpr decimal32 operator--(int) noexcept; // NOLINT : C++14 so constexpr implies const
-    constexpr decimal32& operator-=(decimal32 rhs) noexcept;
 
     friend constexpr decimal32 operator*(decimal32 lhs, decimal32 rhs) noexcept;
-    constexpr decimal32& operator*=(decimal32 rhs) noexcept;
 
     friend constexpr decimal32 operator/(decimal32 lhs, decimal32 rhs) noexcept;
-    constexpr decimal32& operator/=(decimal32 rhs) noexcept;
 
     friend constexpr decimal32 operator%(decimal32 lhs, decimal32 rhs) noexcept;
+
+
+    // 3.2.2.5 Increment and Decrement
+    constexpr decimal32& operator++() noexcept;
+    constexpr decimal32 operator++(int) noexcept; // NOLINT : C++14 so constexpr implies const
+    constexpr decimal32& operator--() noexcept;
+    constexpr decimal32 operator--(int) noexcept; // NOLINT : C++14 so constexpr implies const
+
+    // 3.2.2.6 Compound assignment
+    constexpr decimal32& operator+=(decimal32 rhs) noexcept;
+    constexpr decimal32& operator-=(decimal32 rhs) noexcept;
+    constexpr decimal32& operator*=(decimal32 rhs) noexcept;
+    constexpr decimal32& operator/=(decimal32 rhs) noexcept;
     constexpr decimal32& operator%=(decimal32 rhs) noexcept;
 
     // 3.2.9 comparison operators:

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -209,15 +209,10 @@ public:
 
     // 3.2.8 binary arithmetic operators:
     friend constexpr decimal32 operator+(decimal32 lhs, decimal32 rhs) noexcept;
-
     friend constexpr decimal32 operator-(decimal32 lhs, decimal32 rhs) noexcept;
-
     friend constexpr decimal32 operator*(decimal32 lhs, decimal32 rhs) noexcept;
-
     friend constexpr decimal32 operator/(decimal32 lhs, decimal32 rhs) noexcept;
-
     friend constexpr decimal32 operator%(decimal32 lhs, decimal32 rhs) noexcept;
-
 
     // 3.2.2.5 Increment and Decrement
     constexpr decimal32& operator++() noexcept;

--- a/test/random_decimal32_math.cpp
+++ b/test/random_decimal32_math.cpp
@@ -2,7 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#include <boost/decimal/decimal32.hpp>
+#include <boost/decimal.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <random>
 #include <limits>
@@ -36,6 +36,34 @@ void random_addition(T lower, T upper)
                       << "\nDec 1: " << dec1
                       << "\nVal 2: " << val2
                       << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 + val2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_mixed_addition(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T trunc_val_2 {static_cast<T>(decimal32(val2))};
+
+        const decimal32 res = dec1 + trunc_val_2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 + val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << trunc_val_2
                       << "\nDec res: " << res
                       << "\nInt res: " << val1 + val2 << std::endl;
         }
@@ -100,6 +128,34 @@ void random_subtraction(T lower, T upper)
 }
 
 template <typename T>
+void random_mixed_subtraction(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T trunc_val_2 {static_cast<T>(decimal32(val2))};
+
+        const decimal32 res = dec1 - trunc_val_2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 - val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << trunc_val_2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 - val2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
 void random_multiplication(T lower, T upper)
 {
     std::uniform_int_distribution<T> dist(lower, upper);
@@ -127,6 +183,34 @@ void random_multiplication(T lower, T upper)
     }
 }
 
+template <typename T>
+void random_mixed_multiplication(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
+
+        const decimal32 res {dec1 * dec2};
+        const decimal32 res_int {val1 * val2};
+
+        if (!BOOST_TEST_EQ(res, res_int))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 * val2 << std::endl;
+        }
+    }
+}
+
 int main()
 {
     // Values that won't exceed the range of the significand
@@ -134,31 +218,49 @@ int main()
     random_addition(0, 5'000'000);
     random_addition(0L, 5'000'000L);
     random_addition(0LL, 5'000'000LL);
+    random_mixed_addition(0, 5'000'000);
+    random_mixed_addition(0L, 5'000'000L);
+    random_mixed_addition(0LL, 5'000'000LL);
 
     // Only two negative values
     random_addition(-5'000'000, 0);
     random_addition(-5'000'000L, 0L);
     random_addition(-5'000'000LL, 0LL);
+    random_mixed_addition(-5'000'000, 0);
+    random_mixed_addition(-5'000'000L, 0L);
+    random_mixed_addition(-5'000'000LL, 0LL);
 
     // Only positive values
     random_subtraction(0, 5'000'000);
     random_subtraction(0L, 5'000'000L);
     random_subtraction(0LL, 5'000'000LL);
+    random_mixed_subtraction(0, 5'000'000);
+    random_mixed_subtraction(0L, 5'000'000L);
+    random_mixed_subtraction(0LL, 5'000'000LL);
 
     // Only two negative values
     random_subtraction(-5'000'000, 0);
     random_subtraction(-5'000'000L, 0L);
     random_subtraction(-5'000'000LL, 0LL);
+    random_mixed_subtraction(-5'000'000, 0);
+    random_mixed_subtraction(-5'000'000L, 0L);
+    random_mixed_subtraction(-5'000'000LL, 0LL);
 
     // Mixed Values
     random_subtraction(-5'000'000, 5'000'000);
     random_subtraction(-5'000'000L, 5'000'000L);
     random_subtraction(-5'000'000LL, 5'000'000LL);
+    random_mixed_subtraction(-5'000'000, 5'000'000);
+    random_mixed_subtraction(-5'000'000L, 5'000'000L);
+    random_mixed_subtraction(-5'000'000LL, 5'000'000LL);
 
     // Anything in range
     random_addition(-5'000'000, 5'000'000);
     random_addition(-5'000'000L, 5'000'000L);
     random_addition(-5'000'000LL, 5'000'000LL);
+    random_mixed_addition(-5'000'000, 5'000'000);
+    random_mixed_addition(-5'000'000L, 5'000'000L);
+    random_mixed_addition(-5'000'000LL, 5'000'000LL);
 
     // Anything in the domain
     random_converted_addition(0, (std::numeric_limits<int>::max)() / 2);
@@ -172,18 +274,30 @@ int main()
     random_multiplication(0L, 5'000L);
     random_multiplication(0LL, 5'000LL);
     random_multiplication(0, sqrt_int_max);
+    random_mixed_multiplication(0, 5'000);
+    random_mixed_multiplication(0L, 5'000L);
+    random_mixed_multiplication(0LL, 5'000LL);
+    random_mixed_multiplication(0, sqrt_int_max);
 
     // Only negative values
     random_multiplication(-5'000, 0);
     random_multiplication(-5'000L, 0L);
     random_multiplication(-5'000LL, 0LL);
     random_multiplication(-sqrt_int_max, 0);
+    random_mixed_multiplication(-5'000, 0);
+    random_mixed_multiplication(-5'000L, 0L);
+    random_mixed_multiplication(-5'000LL, 0LL);
+    random_mixed_multiplication(-sqrt_int_max, 0);
 
     // Mixed values
     random_multiplication(-5'000, 5'000);
     random_multiplication(-5'000L, 5'000L);
     random_multiplication(-5'000LL, 5'000LL);
     random_multiplication(-sqrt_int_max, sqrt_int_max);
+    random_mixed_multiplication(-5'000, 5'000);
+    random_mixed_multiplication(-5'000L, 5'000L);
+    random_mixed_multiplication(-5'000LL, 5'000LL);
+    random_mixed_multiplication(-sqrt_int_max, sqrt_int_max);
 
     return boost::report_errors();
 }


### PR DESCRIPTION
ISO allows for arithmetic between any integral type, and any decimal type