### PR TITLE
Enable mixed type comparison

### DIFF
--- a/include/boost/decimal.hpp
+++ b/include/boost/decimal.hpp
@@ -7,5 +7,6 @@
 
 #include <boost/decimal/fwd.hpp>
 #include <boost/decimal/common_math.hpp>
+#include <boost/decimal/common_comp.hpp>
 
 #endif //BOOST_DECIMAL_HPP

--- a/include/boost/decimal/common_comp.hpp
+++ b/include/boost/decimal/common_comp.hpp
@@ -1,0 +1,105 @@
+// Copyright 2023 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_COMMON_COMP_HPP
+#define BOOST_DECIMAL_COMMON_COMP_HPP
+
+#include <boost/decimal/detail/type_traits.hpp>
+#include <boost/decimal/detail/config.hpp>
+#include <type_traits>
+
+namespace boost { namespace decimal {
+
+// Overloads may be any integral type or decimal type
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator==(decimal32 lhs, T rhs) noexcept
+{
+    return lhs == static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator==(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) == rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator!=(decimal32 lhs, T rhs) noexcept
+{
+    return lhs != static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator!=(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) != rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator<(decimal32 lhs, T rhs) noexcept
+{
+    return lhs < static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator<(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) < rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator<=(decimal32 lhs, T rhs) noexcept
+{
+    return lhs <= static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator<=(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) <= rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator>(decimal32 lhs, T rhs) noexcept
+{
+    return lhs > static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator>(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) > rhs;
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator>=(decimal32 lhs, T rhs) noexcept
+{
+    return lhs >= static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr bool operator>=(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) >= rhs;
+}
+
+#ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr std::strong_ordering operator<=>(decimal32 lhs, T rhs) noexcept
+{
+    return lhs <=> static_cast<decimal32>(rhs);
+}
+
+template <typename T, std::enable_if_t<detail::is_integral<T>::value, bool> = true>
+constexpr std::strong_ordering operator<=>(T lhs, decimal32 rhs) noexcept
+{
+    return static_cast<decimal32>(lhs) <=> rhs;
+}
+
+#endif
+
+}} // Namespaces
+
+#endif // BOOST_DECIMAL_COMMON_COMP_HPP

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -524,7 +524,11 @@ constexpr decimal32 operator+(decimal32 lhs, decimal32 rhs) noexcept
         return res;
     }
 
-    const bool lhs_bigger {lhs > rhs};
+    bool lhs_bigger {lhs > rhs};
+    if (lhs.isneg() && rhs.isneg())
+    {
+        lhs_bigger = !lhs_bigger;
+    }
     bool sign {};
 
     // Ensure that lhs is always the larger for ease of implementation

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -890,26 +890,46 @@ constexpr bool operator<(decimal32 lhs, decimal32 rhs) noexcept
         }
     }
 
-    std::uint32_t lhs_real_exp {lhs.full_exponent()};
-    std::uint32_t rhs_real_exp {rhs.full_exponent()};
-    std::uint32_t lhs_significand {lhs.full_significand()};
-    std::uint32_t rhs_significand {rhs.full_significand()};
+    const bool both_neg {lhs.bits_.sign && rhs.bits_.sign};
+    auto lhs_real_exp {lhs.biased_exponent()};
+    auto rhs_real_exp {rhs.biased_exponent()};
+    auto lhs_significand {lhs.full_significand()};
+    auto rhs_significand {rhs.full_significand()};
 
-    // Normalize the significands
+    // Normalize the significands and exponents
     normalize(lhs_significand, lhs_real_exp);
     normalize(rhs_significand, rhs_real_exp);
 
-    if (lhs_real_exp < rhs_real_exp)
+    if (both_neg)
     {
-        return true;
+        if (lhs_real_exp > rhs_real_exp)
+        {
+            return true;
+        }
+        else if (lhs_real_exp < rhs_real_exp)
+        {
+            return false;
+        }
+        else
+        {
+            return lhs_significand > rhs_significand;
+        }
     }
-    else if (lhs_real_exp > rhs_real_exp)
+    else
     {
-        return false;
+        if (lhs_real_exp < rhs_real_exp)
+        {
+            return true;
+        }
+        else if (lhs_real_exp > rhs_real_exp)
+        {
+            return false;
+        }
+        else
+        {
+            return lhs_significand < rhs_significand;
+        }
     }
-
-    // exponents are equal
-    return lhs_significand < rhs_significand;
 }
 
 constexpr bool operator<=(decimal32 lhs, decimal32 rhs) noexcept

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -235,6 +235,10 @@ public:
     friend constexpr bool operator>(decimal32 lhs, decimal32 rhs) noexcept;
     friend constexpr bool operator>=(decimal32 lhs, decimal32 rhs) noexcept;
 
+    #ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+    friend constexpr std::strong_ordering operator<=>(decimal32 lhs, decimal32 rhs) noexcept;
+    #endif
+
     // 3.2.10 Formatted input:
     template <typename charT, typename traits>
     friend std::basic_istream<charT, traits>& operator>>(std::basic_istream<charT, traits>& is, decimal32& d);
@@ -922,6 +926,22 @@ constexpr bool operator>=(decimal32 lhs, decimal32 rhs) noexcept
 {
     return !(lhs < rhs);
 }
+
+#ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+constexpr std::strong_ordering operator<=>(decimal32 lhs, decimal32 rhs) noexcept
+{
+    if (lhs < rhs)
+    {
+        return std::strong_ordering::less;
+    }
+    else if (lhs > rhs)
+    {
+        return std::strong_ordering::greater;
+    }
+
+    return std::strong_ordering::equal;
+}
+#endif
 
 constexpr std::uint32_t decimal32::full_exponent() const noexcept
 {

--- a/include/boost/decimal/detail/config.hpp
+++ b/include/boost/decimal/detail/config.hpp
@@ -152,4 +152,9 @@ typedef unsigned __int128 uint128_t;
 #  define BOOST_DECIMAL_UNLIKELY(x) x
 #endif
 
+#if defined(__cpp_lib_three_way_comparison) && __cpp_lib_three_way_comparison >= 201907L
+#  include <compare>
+#  define BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+#endif
+
 #endif // BOOST_DECIMAL_DETAIL_CONFIG_HPP

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -22,3 +22,4 @@ run test_decimal32.cpp ;
 run roundtrip_decimal32.cpp ;
 run random_decimal32_math.cpp ;
 run test_decimal32_stream.cpp ;
+run random_decimal32_comp.cpp ;

--- a/test/random_decimal32_comp.cpp
+++ b/test/random_decimal32_comp.cpp
@@ -38,6 +38,29 @@ void random_LT(T lower, T upper)
 }
 
 template <typename T>
+void random_mixed_LT(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
+
+        if (!BOOST_TEST_EQ(dec1 < dec2, val1 < val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
 void random_LE(T lower, T upper)
 {
     std::uniform_int_distribution<T> dist(lower, upper);
@@ -49,6 +72,29 @@ void random_LE(T lower, T upper)
 
         const decimal32 dec1 {val1};
         const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 <= dec2, val1 <= val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_mixed_LE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
 
         if (!BOOST_TEST_EQ(dec1 <= dec2, val1 <= val2))
         {
@@ -84,6 +130,29 @@ void random_GT(T lower, T upper)
 }
 
 template <typename T>
+void random_mixed_GT(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
+
+        if (!BOOST_TEST_EQ(dec1 > dec2, val1 > val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
 void random_GE(T lower, T upper)
 {
     std::uniform_int_distribution<T> dist(lower, upper);
@@ -95,6 +164,29 @@ void random_GE(T lower, T upper)
 
         const decimal32 dec1 {val1};
         const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 >= dec2, val1 >= val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_mixed_GE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
 
         if (!BOOST_TEST_EQ(dec1 >= dec2, val1 >= val2))
         {
@@ -130,6 +222,29 @@ void random_EQ(T lower, T upper)
 }
 
 template <typename T>
+void random_mixed_EQ(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
+
+        if (!BOOST_TEST_EQ(dec1 == dec2, val1 == val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
 void random_NE(T lower, T upper)
 {
     std::uniform_int_distribution<T> dist(lower, upper);
@@ -141,6 +256,29 @@ void random_NE(T lower, T upper)
 
         const decimal32 dec1 {val1};
         const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 != dec2, val1 != val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_mixed_NE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
 
         if (!BOOST_TEST_EQ(dec1 != dec2, val1 != val2))
         {
@@ -175,6 +313,29 @@ void random_SPACESHIP(T lower, T upper)
         }
     }
 }
+
+template <typename T>
+void random_mixed_SPACESHIP(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const T dec2 {static_cast<T>(decimal32(val2))};
+
+        if (!BOOST_TEST((dec1 <=> dec2) == (val1 <=> val2)))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
 #endif
 
 int main()
@@ -186,12 +347,26 @@ int main()
     random_LT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_LT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
+    random_mixed_LT(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_LT(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_LT(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_LT(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_LT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_LT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
     random_LE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
     random_LE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
     random_LE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
     random_LE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
     random_LE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_LE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_mixed_LE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_LE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_LE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_LE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_LE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_LE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
     random_GT(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
     random_GT(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
@@ -200,12 +375,26 @@ int main()
     random_GT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_GT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
+    random_mixed_GT(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_GT(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_GT(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_GT(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_GT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_GT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
     random_GE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
     random_GE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
     random_GE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
     random_GE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
     random_GE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_GE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_mixed_GE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_GE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_GE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_GE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_GE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_GE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
     random_EQ(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
     random_EQ(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
@@ -214,12 +403,26 @@ int main()
     random_EQ(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_EQ(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
+    random_mixed_EQ(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_EQ(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_EQ(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_EQ(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_EQ(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_EQ(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
     random_NE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
     random_NE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
     random_NE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
     random_NE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
     random_NE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_NE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_mixed_NE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_NE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_NE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_NE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_NE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_NE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
 
     #ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
     random_SPACESHIP(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
@@ -228,6 +431,13 @@ int main()
     random_SPACESHIP(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
     random_SPACESHIP(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
     random_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_mixed_SPACESHIP(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_mixed_SPACESHIP(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_mixed_SPACESHIP(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_mixed_SPACESHIP(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_mixed_SPACESHIP(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
     return boost::report_errors();

--- a/test/random_decimal32_comp.cpp
+++ b/test/random_decimal32_comp.cpp
@@ -1,0 +1,234 @@
+// Copyright 2023 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <random>
+#include <limits>
+
+using namespace boost::decimal;
+
+static constexpr auto N {1024U};
+
+// NOLINTNEXTLINE : Seed with a constant for repeatability
+static std::mt19937_64 rng(42); // NOSONAR : Global rng is not const
+
+template <typename T>
+void random_LT(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 < dec2, val1 < val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_LE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 <= dec2, val1 <= val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_GT(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 > dec2, val1 > val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_GE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 >= dec2, val1 >= val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_EQ(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 == dec2, val1 == val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+template <typename T>
+void random_NE(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST_EQ(dec1 != dec2, val1 != val2))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+
+#ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+template <typename T>
+void random_SPACESHIP(T lower, T upper)
+{
+    std::uniform_int_distribution<T> dist(lower, upper);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const decimal32 dec1 {val1};
+        const decimal32 dec2 {val2};
+
+        if (!BOOST_TEST((dec1 <=> dec2) == (val1 <=> val2)))
+        {
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2 << std::endl;
+        }
+    }
+}
+#endif
+
+int main()
+{
+    random_LT(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_LT(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_LT(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_LT(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_LT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_LT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_LE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_LE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_LE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_LE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_LE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_LE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_GT(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_GT(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_GT(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_GT(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_GT(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_GT(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_GE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_GE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_GE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_GE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_GE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_GE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_EQ(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_EQ(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_EQ(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_EQ(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_EQ(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_EQ(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    random_NE(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_NE(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_NE(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_NE(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_NE(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_NE(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+
+    #ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
+    random_SPACESHIP(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+    random_SPACESHIP(std::numeric_limits<unsigned>::min(), std::numeric_limits<unsigned>::max());
+    random_SPACESHIP(std::numeric_limits<long>::min(), std::numeric_limits<long>::max());
+    random_SPACESHIP(std::numeric_limits<unsigned long>::min(), std::numeric_limits<unsigned long>::max());
+    random_SPACESHIP(std::numeric_limits<long long>::min(), std::numeric_limits<long long>::max());
+    random_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
+    #endif
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Like arithmetic operators decimal32 is allowed to be compared to all integer types