### PR TITLE
Change handling of ilogb

### DIFF
--- a/include/boost/decimal/detail/cmath/frexp.hpp
+++ b/include/boost/decimal/detail/cmath/frexp.hpp
@@ -48,7 +48,7 @@ constexpr auto frexp(T v, int* expon) noexcept -> T
         auto t =
             static_cast<int>
             (
-                  static_cast<long double>(ilogb(result_frexp))
+                  static_cast<long double>(ilogb(result_frexp) - detail::bias)
                 * static_cast<long double>(3.3222591362126245847176079734219269102990033L)
             );
 

--- a/include/boost/decimal/detail/cmath/ilogb.hpp
+++ b/include/boost/decimal/detail/cmath/ilogb.hpp
@@ -8,23 +8,32 @@
 #include <boost/decimal/fwd.hpp>
 #include <boost/decimal/detail/type_traits.hpp>
 #include <type_traits>
+#include <climits>
 #include <cmath>
 
 namespace boost { namespace decimal {
 
 // TODO(mborland): Allow conversion between decimal types via a promotion system
 
-template<typename T, std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>>
-constexpr auto ilogb(T d) noexcept -> int
+template <typename T>
+constexpr auto ilogb(T d) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>
 {
-    const auto offset = int { detail::num_digits(d.full_significand()) - 1 };
-
-    auto expval = int { static_cast<int>(d.full_exponent()) + static_cast<int>(offset - detail::bias) };
-
-    if (offset == 0)
+    if (d == 0)
     {
-        --expval;
+        return FP_ILOGB0;
     }
+    else if (isinf(d))
+    {
+        return INT_MAX;
+    }
+    else if (isnan(d))
+    {
+        return FP_ILOGBNAN;
+    }
+
+    const auto offset { detail::num_digits(d.full_significand()) - 1 };
+
+    auto expval {static_cast<int>(d.unbiased_exponent()) + static_cast<int>(offset) };
 
     return expval;
 }

--- a/test/test_decimal32_cmath.cpp
+++ b/test/test_decimal32_cmath.cpp
@@ -505,6 +505,16 @@ void test_fdim()
     BOOST_TEST_EQ(fdim(Dec(1), Dec(1)), Dec(0));
 }
 
+template <typename Dec>
+void test_ilogb()
+{
+    BOOST_TEST_EQ(ilogb(Dec(1,0)), 101);
+    BOOST_TEST_EQ(ilogb(Dec(10, 0)), 102);
+    BOOST_TEST_EQ(ilogb(Dec(0)), FP_ILOGB0);
+    BOOST_TEST_EQ(ilogb(BOOST_DECIMAL_DEC_INFINITY), INT_MAX);
+    BOOST_TEST_EQ(ilogb(BOOST_DECIMAL_DEC_NAN), FP_ILOGBNAN);
+}
+
 int main()
 {
     test_fmax<decimal32>();
@@ -539,6 +549,8 @@ int main()
     test_remquo<decimal32>();
 
     test_fdim<decimal32>();
+
+    test_ilogb<decimal32>();
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Add the non-finite paths and changes the return to be the unbiased exponent:

`
Extracts the value of the unbiased exponent from the floating-point argument num, and returns it as a signed integer value. The library provides overloads of std::ilogb for all cv-unqualified floating-point types as the type of the parameter num. (since C++23)
`

Closes: #86 

@ckormanyos 