### PR TITLE
Awarenes for __cplusplus and _MSC_VER

### DIFF
--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -2110,7 +2110,7 @@ public:
     BOOST_DECIMAL_ATTRIBUTE_UNUSED static constexpr bool has_signaling_NaN = true;
 
     // These members were deprecated in C++23
-    #if __cplusplus <= 202002L || _MSVC_LANG <= 202002L
+    #if ((!defined(_MSC_VER) && (__cplusplus <= 202002L)) || (defined(_MSC_VER) && (_MSVC_LANG <= 202002L)))
     BOOST_DECIMAL_ATTRIBUTE_UNUSED static constexpr std::float_denorm_style has_denorm = std::denorm_present;
     BOOST_DECIMAL_ATTRIBUTE_UNUSED static constexpr bool has_denorm_loss = true;
     #endif


### PR DESCRIPTION
The purpose of this PR is to figure out better ways to detect modern `__cplusplus` version(s).

Hi Matt (@mborland), my VC142 tests positive for the first PP-query in

```
#if __cplusplus <= 202002L || _MSVC_LANG <= 202002L
```

This is because MSVC empirically seems to have poor support for `__cplusplus`.