### PR TITLE
Update and test exp 64-bit and Pade approx

### DIFF
--- a/include/boost/decimal/detail/cmath/exp.hpp
+++ b/include/boost/decimal/detail/cmath/exp.hpp
@@ -79,7 +79,7 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
             const T top = T { UINT8_C(84), 0 } * x * ( T { UINT16_C(7920), 0 } + ( T { UINT8_C(240), 0 } + x2) * x2);
             const T bot = T { UINT32_C(665280), 0 } + x * (T { INT32_C(-332640), 0 } + x * (T { UINT32_C(75600), 0 } + x * (T { INT16_C(-10080), 0 } + x * (T { UINT16_C(840), 0 } + (T { INT8_C(-42), 0 } + x) * x))));
 
-            result = (bot + top) / bot;
+            result = one + (top / bot);
 
             //result *= result;
 
@@ -91,7 +91,7 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
                 }
                 else
                 {
-                    result *= ldexp(T { 2, 0 }, nf2);
+                    result *= pow(T { 2, 0 }, nf2);
                 }
             }
         }

--- a/include/boost/decimal/detail/cmath/exp.hpp
+++ b/include/boost/decimal/detail/cmath/exp.hpp
@@ -66,69 +66,22 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
                 x -= (numbers::ln2_v<T> * nf2);
             }
 
-            // Specifically derive a polynomial expansion for Exp[x] - 1 for this work.
-            //   Table[{x, Exp[x] - 1}, {x, -Log[2], Log[2], 1/120}]
-            //   N[%, 48]
-            //   Fit[%, {x, x^2, x^3, x^4, x^5, x^6, x^7, x^8, x^9, x^10, x^11, x^12, x^13, x^14}, x]
+            //x /= T { 2, 0 };
 
-            // 0.10000000000000000031253715431509025238419040635E+01 x + 
-            // 0.49999999999999999984496573772883553268579270080E+00 x^2 + 
-            // 0.16666666666666640990495014803355939249488014570E+00 x^3 + 
-            // 0.41666666666666669211628619573955168058871592450E-01 x^4 + 
-            // 0.83333333333393951785026963540146404509293729880E-02 x^5 + 
-            // 0.13888888888889531930153627330611258989144651196E-02 x^6 + 
-            // 0.19841269834993605726436085548163823346843735024E-03 x^7 + 
-            // 0.24801587300034818820409788738954033986515647940E-04 x^8 + 
-            // 0.27557322544760672800374557020710996254381528860E-05 x^9 + 
-            // 0.27557320418080198508304620049466379620223056430E-06 x^10 + 
-            // 0.25051171110638608777162102769329794003047092510E-07 x^11 + 
-            // 0.20876329425290606504750348960465969428397241893E-08 x^12 + 
-            // 0.16193258511277332147199978827602163814705181995E-09 x^13 + 
-            // 0.11543684568750446489173904407189863158196792345E-10 x^14
+            // PadeApproximant[Exp[x] - 1, {x, 0, {6, 6}}]
+            // FullSimplify[%]
+            //   (84 x (7920 + 240 x^2 + x^4))
+            // / (665280 + x (-332640 + x (75600 + x (-10080 + x (840 + (-42 + x) x)))))
 
-            using coefficient_array_type = std::array<T, static_cast<std::size_t>(UINT8_C(14))>;
+            const auto x2 = x * x;
 
-            // TODO(ckormanyos) Is a Pade approximation more precise or faster?
-            // And, ... how can you make it scalable if you go ahead and "Pade"-it?
+            // Use the small-argument Pade approximation having coefficients shown above.
+            const T top = T { UINT8_C(84), 0 } * x * ( T { UINT16_C(7920), 0 } + ( T { UINT8_C(240), 0 } + x2) * x2);
+            const T bot = T { UINT32_C(665280), 0 } + x * (T { INT32_C(-332640), 0 } + x * (T { UINT32_C(75600), 0 } + x * (T { INT16_C(-10080), 0 } + x * (T { UINT16_C(840), 0 } + (T { INT8_C(-42), 0 } + x) * x))));
 
-            #if (defined(__clang__) && (__clang__ < 6))
-            #  pragma clang diagnostic push
-            #  pragma clang diagnostic ignored "-Wmissing-braces"
-            #endif
+            result = (bot + top) / bot;
 
-            constexpr auto coefficient_table =
-                coefficient_array_type
-                {
-                    T { 1,  0 },                                       // * x
-                    T { 5, -1 },                                       // * x^2
-                    T { UINT64_C(166'666'666'666'666'409), -18 -  0 }, // * x^3
-                    T { UINT64_C(416'666'666'666'666'692), -18 -  1 }, // * x^4
-                    T { UINT64_C(833'333'333'333'939'517), -18 -  2 }, // * x^5
-                    T { UINT64_C(138'888'888'888'895'319), -18 -  2 }, // * x^6
-                    T { UINT64_C(198'412'698'349'936'057), -18 -  3 }, // * x^7
-                    T { UINT64_C(248'015'873'000'348'188), -18 -  4 }, // * x^8
-                    T { UINT64_C(275'573'225'447'606'728), -18 -  5 }, // * x^9
-                    T { UINT64_C(275'573'204'180'801'985), -18 -  6 }, // * x^10
-                    T { UINT64_C(250'511'711'106'386'087), -18 -  7 }, // * x^11
-                    T { UINT64_C(208'763'294'252'906'065), -18 -  8 }, // * x^12
-                    T { UINT64_C(161'932'585'112'773'321), -18 -  9 }, // * x^13
-                    T { UINT64_C(115'436'845'687'504'464), -18 - 10 }  // * x^14
-                };
-
-            #if (defined(__clang__) && (__clang__ < 6))
-            #  pragma clang diagnostic pop
-            #endif
-
-            auto rit = coefficient_table.crbegin() + static_cast<std::size_t>((sizeof(T) == 4U) ? 5U : 0U);
-
-            result = *rit;
-
-            while(rit != coefficient_table.crend())
-            {
-                result = fma(result, x, *rit++);
-            }
-
-            result = fma(result, x, one);
+            //result *= result;
 
             if (nf2 > 0)
             {
@@ -138,7 +91,7 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
                 }
                 else
                 {
-                    result *= pow(T { 2, 0 }, nf2);
+                    result *= ldexp(T { 2, 0 }, nf2);
                 }
             }
         }

--- a/include/boost/decimal/detail/cmath/exp.hpp
+++ b/include/boost/decimal/detail/cmath/exp.hpp
@@ -66,8 +66,6 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
                 x -= (numbers::ln2_v<T> * nf2);
             }
 
-            //x /= T { 2, 0 };
-
             // PadeApproximant[Exp[x] - 1, {x, 0, {6, 6}}]
             // FullSimplify[%]
             //   (84 x (7920 + 240 x^2 + x^4))
@@ -81,13 +79,11 @@ constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating
 
             result = one + (top / bot);
 
-            //result *= result;
-
             if (nf2 > 0)
             {
                 if (nf2 < 64)
                 {
-                    result *= T { static_cast<std::uint64_t>(1ULL << static_cast<unsigned>(nf2)), 0 };
+                    result *= T { static_cast<std::uint64_t>(UINT64_C(1) << static_cast<unsigned>(nf2)), 0 };
                 }
                 else
                 {

--- a/test/test_acosh.cpp
+++ b/test/test_acosh.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -122,7 +122,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -135,7 +135,7 @@ namespace local
       result_is_ok = (result_val_nan_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -148,7 +148,7 @@ namespace local
       result_is_ok = (result_val_nan_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -161,7 +161,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -174,7 +174,7 @@ namespace local
       result_is_ok = (result_val_one_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -187,7 +187,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_cosh.cpp
+++ b/test/test_cosh.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -124,7 +124,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -137,7 +137,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -150,7 +150,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -163,7 +163,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -176,7 +176,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_edges_and_behave.cpp
+++ b/test/test_edges_and_behave.cpp
@@ -71,7 +71,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -115,7 +115,7 @@ namespace local
       }
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -369,7 +369,7 @@ namespace local
       result_is_ok = (result_sin_cos_tiny_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -390,7 +390,7 @@ namespace local
       result_is_ok = (result_sin_con_non_normal_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -404,7 +404,7 @@ namespace local
       result_is_ok = (result_ilogb_inf_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_exp.cpp
+++ b/test/test_exp.cpp
@@ -96,9 +96,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x2000)) : static_cast<std::uint32_t>(UINT32_C(0x400));
+    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x1000)) : static_cast<std::uint32_t>(UINT32_C(0x200));
     #else
-    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x200)) : static_cast<std::uint32_t>(UINT32_C(0x40));
+    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x100)) : static_cast<std::uint32_t>(UINT32_C(0x20));
     #endif
 
     for( ; trials < count; ++trials)
@@ -149,7 +149,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -162,7 +162,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -175,7 +175,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -188,7 +188,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -201,7 +201,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -228,7 +228,7 @@ namespace
 
     auto result_is_ok = true;
 
-    const auto result_pos_is_ok = local::test_exp<decimal_type, float_type>(128, false, 0.03125L, 32.0L);
+    const auto result_pos_is_ok = local::test_exp<decimal_type, float_type>(128, false, 35.0L, 80.0L);
     const auto result_neg_is_ok = local::test_exp<decimal_type, float_type>(128, true,  0.03125L, 32.0L);
 
     const auto result_pos_narrow_is_ok = local::test_exp<decimal_type, float_type>(64, false, 0.25L, 4.0L);
@@ -261,15 +261,61 @@ auto main() -> int
   auto result_is_ok = true;
 
   {
-    const auto result_decimal32_is_ok = test_all<boost::decimal::decimal32, float>();
+    using decimal_type = boost::decimal::decimal32;
+    using float_type   = float;
 
-    result_is_ok = result_is_ok && result_decimal32_is_ok;
+    const auto result_pos_is_ok = local::test_exp<decimal_type, float_type>(128, false, 0.03125L, 32.0L);
+    const auto result_neg_is_ok = local::test_exp<decimal_type, float_type>(128, true,  0.03125L, 32.0L);
+
+    const auto result_pos_narrow_is_ok = local::test_exp<decimal_type, float_type>(64, false, 0.25L, 4.0L);
+    const auto result_neg_narrow_is_ok = local::test_exp<decimal_type, float_type>(64, true,  0.25L, 4.0L);
+
+    const auto result_edge_is_ok = local::test_exp_edge<decimal_type, float_type>();
+
+    BOOST_TEST(result_pos_is_ok);
+    BOOST_TEST(result_neg_is_ok);
+
+    BOOST_TEST(result_pos_narrow_is_ok);
+    BOOST_TEST(result_neg_narrow_is_ok);
+
+    BOOST_TEST(result_edge_is_ok);
+
+    result_is_ok = (result_pos_is_ok && result_is_ok);
+    result_is_ok = (result_neg_is_ok && result_is_ok);
+
+    result_is_ok = (result_pos_narrow_is_ok && result_is_ok);
+    result_is_ok = (result_neg_narrow_is_ok && result_is_ok);
+
+    result_is_ok = (result_edge_is_ok && result_is_ok);
   }
 
   {
-    const auto result_decimal64_is_ok = test_all<boost::decimal::decimal64, double>();
+    using decimal_type = boost::decimal::decimal64;
+    using float_type   = double;
 
-    result_is_ok = result_is_ok && result_decimal64_is_ok;
+    const auto result_pos_lo_is_ok = local::test_exp<decimal_type, float_type>(128, false, 0.25L, 32.0L);
+    const auto result_neg_lo_is_ok = local::test_exp<decimal_type, float_type>(128, true,  0.25L, 32.0L);
+
+    const auto result_pos_hi_is_ok = local::test_exp<decimal_type, float_type>(1536, false, 48.0L, 256.0L);
+    const auto result_neg_hi_is_ok = local::test_exp<decimal_type, float_type>(1536, true,  48.0L, 256.0L);
+
+    const auto result_edge_is_ok = local::test_exp_edge<decimal_type, float_type>();
+
+    BOOST_TEST(result_pos_lo_is_ok);
+    BOOST_TEST(result_neg_lo_is_ok);
+
+    BOOST_TEST(result_pos_hi_is_ok);
+    BOOST_TEST(result_neg_hi_is_ok);
+
+    BOOST_TEST(result_edge_is_ok);
+
+    result_is_ok = (result_pos_lo_is_ok && result_is_ok);
+    result_is_ok = (result_neg_lo_is_ok && result_is_ok);
+
+    result_is_ok = (result_pos_hi_is_ok && result_is_ok);
+    result_is_ok = (result_neg_hi_is_ok && result_is_ok);
+
+    result_is_ok = (result_edge_is_ok && result_is_ok);
   }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);

--- a/test/test_exp.cpp
+++ b/test/test_exp.cpp
@@ -20,6 +20,8 @@
 #endif
 
 #include <chrono>
+#include <iomanip>
+#include <iostream>
 #include <limits>
 #include <random>
 

--- a/test/test_exp.cpp
+++ b/test/test_exp.cpp
@@ -3,6 +3,22 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#if defined(__clang__)
+  #if defined __has_feature
+  #if __has_feature(thread_sanitizer)
+  #define BOOST_DECIMAL_REDUCE_TEST_DEPTH
+  #endif
+  #endif
+#elif defined(__GNUC__)
+  #if defined(__SANITIZE_THREAD__)
+  #define BOOST_DECIMAL_REDUCE_TEST_DEPTH
+  #endif
+#elif defined(_MSC_VER)
+  #if defined(_DEBUG)
+  #define BOOST_DECIMAL_REDUCE_TEST_DEPTH
+  #endif
+#endif
+
 #include <chrono>
 #include <limits>
 #include <random>
@@ -10,8 +26,8 @@
 #include <boost/decimal.hpp>
 #include <boost/core/lightweight_test.hpp>
 
-auto my_zero() -> boost::decimal::decimal32&;
-auto my_one () -> boost::decimal::decimal32&;
+template<typename DecimalType> auto my_zero() -> DecimalType& { using decimal_type = DecimalType; static decimal_type val_zero { 0, 0 }; return val_zero; }
+template<typename DecimalType> auto my_one () -> DecimalType& { using decimal_type = DecimalType; static decimal_type val_one  { 1, 0 }; return val_one; }
 
 namespace local
 {
@@ -57,9 +73,11 @@ namespace local
     return result_is_ok;
   }
 
+  template<typename DecimalType, typename FloatType>
   auto test_exp(const int tol_factor, const bool negate, const long double range_lo, const long double range_hi) -> bool
   {
-    using decimal_type = boost::decimal::decimal32;
+    using decimal_type = DecimalType;
+    using float_type   = FloatType;
 
     std::random_device rd;
     std::mt19937_64 gen(rd());
@@ -67,10 +85,10 @@ namespace local
     gen.seed(time_point<typename std::mt19937_64::result_type>());
 
     auto dis =
-      std::uniform_real_distribution<float>
+      std::uniform_real_distribution<float_type>
       {
-        static_cast<float>(range_lo),
-        static_cast<float>(range_hi)
+        static_cast<float_type>(range_lo),
+        static_cast<float_type>(range_hi)
       };
 
     auto result_is_ok = true;
@@ -78,9 +96,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x2000)) : static_cast<std::uint32_t>(UINT32_C(0x400));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x200)) : static_cast<std::uint32_t>(UINT32_C(0x40));
     #endif
 
     for( ; trials < count; ++trials)
@@ -95,15 +113,15 @@ namespace local
       const auto val_flt = exp(x_flt);
       const auto val_dec = exp(x_dec);
 
-      const auto result_val_is_ok = is_close_fraction(val_flt, static_cast<float>(val_dec), std::numeric_limits<float>::epsilon() * tol_factor);
+      const auto result_val_is_ok = is_close_fraction(val_flt, static_cast<float_type>(val_dec), static_cast<float_type>(std::numeric_limits<decimal_type>::epsilon()) * tol_factor);
 
       result_is_ok = (result_val_is_ok && result_is_ok);
 
       if(!result_val_is_ok)
       {
-        std::cout << "x_flt  : " <<                    x_flt   << std::endl;
-        std::cout << "val_flt: " << std::scientific << val_flt << std::endl;
-        std::cout << "val_dec: " << std::scientific << val_dec << std::endl;
+        std::cout << "x_flt  : " << std::scientific << std::setprecision(std::numeric_limits<float_type>::digits10) << x_flt   << std::endl;
+        std::cout << "val_flt: " << std::scientific << std::setprecision(std::numeric_limits<float_type>::digits10) << val_flt << std::endl;
+        std::cout << "val_dec: " << std::scientific << std::setprecision(std::numeric_limits<float_type>::digits10) << val_dec << std::endl;
 
         break;
       }
@@ -114,13 +132,20 @@ namespace local
     return result_is_ok;
   }
 
+  template<typename DecimalType, typename FloatType>
   auto test_exp_edge() -> bool
   {
-    using decimal_type = boost::decimal::decimal32;
+    using decimal_type = DecimalType;
+    using float_type   = FloatType;
 
     std::mt19937_64 gen;
 
-    std::uniform_real_distribution<float> dist(1.01F, 1.04F);
+    std::uniform_real_distribution<float_type>
+      dist
+      (
+        static_cast<float_type>(1.01L),
+        static_cast<float_type>(1.04L)
+      );
 
     auto result_is_ok = true;
 
@@ -156,7 +181,7 @@ namespace local
 
       const auto val_inf_neg = exp(-std::numeric_limits<decimal_type>::infinity() * static_cast<decimal_type>(dist(gen)));
 
-      const auto result_val_inf_neg_is_ok = (val_inf_neg == ::my_zero());
+      const auto result_val_inf_neg_is_ok = (val_inf_neg == ::my_zero<decimal_type>());
 
       BOOST_TEST(result_val_inf_neg_is_ok);
 
@@ -167,9 +192,9 @@ namespace local
     {
       static_cast<void>(i);
 
-      const auto val_zero_pos = exp(::my_zero());
+      const auto val_zero_pos = exp(::my_zero<decimal_type>());
 
-      const auto result_val_zero_pos_is_ok = (val_zero_pos == ::my_one());
+      const auto result_val_zero_pos_is_ok = (val_zero_pos == ::my_one<decimal_type>());
 
       BOOST_TEST(result_val_zero_pos_is_ok);
 
@@ -180,9 +205,9 @@ namespace local
     {
       static_cast<void>(i);
 
-      const auto val_zero_neg = exp(-::my_zero());
+      const auto val_zero_neg = exp(-::my_zero<decimal_type>());
 
-      const auto result_val_zero_neg_is_ok = (val_zero_neg == ::my_one());
+      const auto result_val_zero_neg_is_ok = (val_zero_neg == ::my_one<decimal_type>());
 
       BOOST_TEST(result_val_zero_neg_is_ok);
 
@@ -191,50 +216,63 @@ namespace local
 
     return result_is_ok;
   }
-
 } // namespace local
+
+namespace
+{
+  template<typename DecimalType, typename FloatType>
+  auto test_all() -> bool
+  {
+    using decimal_type = DecimalType;
+    using float_type   = FloatType;
+
+    auto result_is_ok = true;
+
+    const auto result_pos_is_ok = local::test_exp<decimal_type, float_type>(128, false, 0.03125L, 32.0L);
+    const auto result_neg_is_ok = local::test_exp<decimal_type, float_type>(128, true,  0.03125L, 32.0L);
+
+    const auto result_pos_narrow_is_ok = local::test_exp<decimal_type, float_type>(64, false, 0.25L, 4.0L);
+    const auto result_neg_narrow_is_ok = local::test_exp<decimal_type, float_type>(64, true,  0.25L, 4.0L);
+
+    const auto result_edge_is_ok = local::test_exp_edge<decimal_type, float_type>();
+
+    BOOST_TEST(result_pos_is_ok);
+    BOOST_TEST(result_neg_is_ok);
+
+    BOOST_TEST(result_pos_narrow_is_ok);
+    BOOST_TEST(result_neg_narrow_is_ok);
+
+    BOOST_TEST(result_edge_is_ok);
+
+    result_is_ok = (result_pos_is_ok && result_is_ok);
+    result_is_ok = (result_neg_is_ok && result_is_ok);
+
+    result_is_ok = (result_pos_narrow_is_ok && result_is_ok);
+    result_is_ok = (result_neg_narrow_is_ok && result_is_ok);
+
+    result_is_ok = (result_edge_is_ok && result_is_ok);
+
+    return result_is_ok;
+  }
+} // namespace
 
 auto main() -> int
 {
   auto result_is_ok = true;
 
-  const auto result_pos_is_ok = local::test_exp(96, false, 0.03125L, 32.0L);
-  const auto result_neg_is_ok = local::test_exp(96, true,  0.03125L, 32.0L);
+  {
+    const auto result_decimal32_is_ok = test_all<boost::decimal::decimal32, float>();
 
-  const auto result_pos_narrow_is_ok = local::test_exp(16, false, 0.25L, 4.0L);
-  const auto result_neg_narrow_is_ok = local::test_exp(24, true,  0.25L, 4.0L);
+    result_is_ok = result_is_ok && result_decimal32_is_ok;
+  }
 
-  const auto result_pos_wide_is_ok = local::test_exp(112, false, 0.0125L, 80.0L);
-  const auto result_neg_wide_is_ok = local::test_exp(112, true,  0.0125L, 80.0L);
+  {
+    const auto result_decimal64_is_ok = test_all<boost::decimal::decimal64, double>();
 
-  const auto result_edge_is_ok = local::test_exp_edge();
-
-  BOOST_TEST(result_pos_is_ok);
-  BOOST_TEST(result_neg_is_ok);
-
-  BOOST_TEST(result_pos_narrow_is_ok);
-  BOOST_TEST(result_neg_narrow_is_ok);
-
-  BOOST_TEST(result_pos_wide_is_ok);
-  BOOST_TEST(result_neg_wide_is_ok);
-
-  BOOST_TEST(result_edge_is_ok);
-
-  result_is_ok = (result_pos_is_ok  && result_is_ok);
-  result_is_ok = (result_neg_is_ok  && result_is_ok);
-
-  result_is_ok = (result_pos_narrow_is_ok  && result_is_ok);
-  result_is_ok = (result_neg_narrow_is_ok  && result_is_ok);
-
-  result_is_ok = (result_pos_wide_is_ok  && result_is_ok);
-  result_is_ok = (result_neg_wide_is_ok  && result_is_ok);
-
-  result_is_ok = (result_edge_is_ok && result_is_ok);
+    result_is_ok = result_is_ok && result_decimal64_is_ok;
+  }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);
 
   return (result_is_ok ? 0 : -1);
 }
-
-auto my_zero() -> boost::decimal::decimal32& { static boost::decimal::decimal32 val_zero { 0, 0 }; return val_zero; }
-auto my_one () -> boost::decimal::decimal32& { static boost::decimal::decimal32 val_one  { 1, 0 }; return val_one; }

--- a/test/test_exp.cpp
+++ b/test/test_exp.cpp
@@ -98,7 +98,7 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x1000)) : static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x1000)) : static_cast<std::uint32_t>(UINT32_C(0x100));
     #else
     constexpr auto count = (sizeof(decimal_type) == static_cast<std::size_t>(UINT8_C(4))) ? static_cast<std::uint32_t>(UINT32_C(0x100)) : static_cast<std::uint32_t>(UINT32_C(0x20));
     #endif

--- a/test/test_expm1.cpp
+++ b/test/test_expm1.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -124,7 +124,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -137,7 +137,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -150,7 +150,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -163,7 +163,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -176,7 +176,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_frexp_ldexp.cpp
+++ b/test/test_frexp_ldexp.cpp
@@ -135,7 +135,7 @@ namespace local
   auto test_frexp_ldexp() -> bool
   {
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto test_frexp_ldexp_depth = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto test_frexp_ldexp_depth = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
     constexpr auto test_frexp_ldexp_depth = static_cast<std::uint32_t>(UINT32_C(0x400));
     #endif

--- a/test/test_log.cpp
+++ b/test/test_log.cpp
@@ -80,9 +80,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)

--- a/test/test_log1p.cpp
+++ b/test/test_log1p.cpp
@@ -80,9 +80,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -141,7 +141,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -154,7 +154,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -167,7 +167,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -180,7 +180,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -193,7 +193,7 @@ namespace local
       result_is_ok = (result_val_zero_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -206,7 +206,7 @@ namespace local
       result_is_ok = (result_val_one_minus_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_sinh.cpp
+++ b/test/test_sinh.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -124,7 +124,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -137,7 +137,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -150,7 +150,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -163,7 +163,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -176,7 +176,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_sqrt.cpp
+++ b/test/test_sqrt.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -122,7 +122,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -135,7 +135,7 @@ namespace local
       result_is_ok = (result_val_nan_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -148,7 +148,7 @@ namespace local
       result_is_ok = (result_val_nan_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -161,7 +161,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -174,7 +174,7 @@ namespace local
       result_is_ok = (result_val_one_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -187,7 +187,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 

--- a/test/test_tanh.cpp
+++ b/test/test_tanh.cpp
@@ -78,9 +78,9 @@ namespace local
     auto trials = static_cast<std::uint32_t>(UINT8_C(0));
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x2000));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x1000));
     #else
-    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x200));
+    constexpr auto count = static_cast<std::uint32_t>(UINT32_C(0x100));
     #endif
 
     for( ; trials < count; ++trials)
@@ -124,7 +124,7 @@ namespace local
 
     auto result_is_ok = true;
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -137,7 +137,7 @@ namespace local
       result_is_ok = (result_val_nan_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -150,7 +150,7 @@ namespace local
       result_is_ok = (result_val_inf_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -163,7 +163,7 @@ namespace local
       result_is_ok = (result_val_inf_neg_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 
@@ -176,7 +176,7 @@ namespace local
       result_is_ok = (result_val_zero_pos_is_ok && result_is_ok);
     }
 
-    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(10)); ++i)
+    for(auto i = static_cast<unsigned>(UINT8_C(0)); i < static_cast<unsigned>(UINT8_C(4)); ++i)
     {
       static_cast<void>(i);
 


### PR DESCRIPTION
The purpose of this PR is to extend the testing of the `exp()` function (known from `<cmath>`) to 64-bit decimal.

Also in this PR it was decided to see how the Pade approximation plays out for `exp()`, as this seems to give better precision for lower run-time cost.