### PR TITLE
Remove cxxstd=2b for clang < 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,31 +172,31 @@ jobs:
               - clang-11
           - toolset: clang
             compiler: clang++-12
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "03,11,14,17,20"
             os: ubuntu-22.04
             install:
               - clang-12
           - toolset: clang
             compiler: clang++-13
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "03,11,14,17,20"
             os: ubuntu-22.04
             install:
               - clang-13
           - toolset: clang
             compiler: clang++-14
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "03,11,14,17,20"
             os: ubuntu-22.04
             install:
               - clang-14
           - toolset: clang
             compiler: clang++-14
-            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu,2b-gnu"
+            cxxstd: "03-gnu,11-gnu,14-gnu,17-gnu,20-gnu"
             os: ubuntu-22.04
             install:
               - clang-14
           - toolset: clang
             compiler: clang++-15
-            cxxstd: "03,11,14,17,20,2b"
+            cxxstd: "03,11,14,17,20"
             os: ubuntu-22.04
             install:
               - clang-15


### PR DESCRIPTION
Avoids: https://stackoverflow.com/questions/77164931/clang-error-on-standard-library-depending-on-std-c2b-version-and-warning-wh

@ckormanyos you may be hitting this in your other libraries. Fixed it this morning on charconv too.