### PR TITLE
Remove boost.config dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,6 @@ add_library(Boost::decimal ALIAS boost_decimal)
 
 target_include_directories(boost_decimal INTERFACE include)
 
-target_link_libraries(boost_decimal
-        INTERFACE
-        Boost::config
-        )
-
 target_compile_features(boost_decimal INTERFACE cxx_std_14)
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -2357,14 +2357,14 @@ constexpr auto fmad32(decimal32 x, decimal32 y, decimal32 z) noexcept -> decimal
 namespace std {
 
 template <>
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
 class numeric_limits<boost::decimal::decimal32>
 #else
 struct numeric_limits<boost::decimal::decimal32>
 #endif
 {
 
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
 public:
 #endif
 

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -2306,14 +2306,14 @@ constexpr auto fmad64(decimal64 x, decimal64 y, decimal64 z) noexcept -> decimal
 namespace std {
 
 template <>
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
 class numeric_limits<boost::decimal::decimal64>
 #else
 struct numeric_limits<boost::decimal::decimal64>
 #endif
 {
 
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
     public:
 #endif
 

--- a/include/boost/decimal/detail/config.hpp
+++ b/include/boost/decimal/detail/config.hpp
@@ -5,16 +5,6 @@
 #ifndef BOOST_DECIMAL_DETAIL_CONFIG_HPP
 #define BOOST_DECIMAL_DETAIL_CONFIG_HPP
 
-#ifdef __has_include
-#  if !__has_include(<boost/config.hpp>)
-#    define BOOST_DECIMAL_STANDALONE
-#  endif
-#endif
-
-#ifndef BOOST_DECIMAL_STANDALONE
-#  include <boost/config.hpp>
-#endif
-
 // Determine endianness
 #if defined(_WIN32)
 
@@ -160,14 +150,10 @@ typedef unsigned __int128 uint128_t;
 
 #define BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION
 
-#ifndef BOOST_DECIMAL_STANDALONE
-#  define BOOST_DECIMAL_ATTRIBUTE_UNUSED BOOST_ATTRIBUTE_UNUSED
-#else
-#  if defined(___GNUC__) || defined(__clang__)
+#if defined(___GNUC__) || defined(__clang__)
 #    define BOOST_DECIMAL_ATTRIBUTE_UNUSED __attribute__((__unused__))
-#  else
+#else
 #    define BOOST_DECIMAL_ATTRIBUTE_UNUSED
-#  endif
 #endif
 
 #if !defined(__cpp_if_constexpr) || (__cpp_if_constexpr < 201606L)

--- a/include/boost/decimal/detail/config.hpp
+++ b/include/boost/decimal/detail/config.hpp
@@ -72,7 +72,7 @@
 #endif
 
 // Include intrinsics if available
-#if defined(BOOST_MSVC) || defined(_MSC_VER)
+#if defined(_MSC_VER)
 #  include <intrin.h>
 #  if defined(_WIN64)
 #    define BOOST_DECIMAL_HAS_MSVC_64BIT_INTRINSICS

--- a/include/boost/decimal/detail/emulated128.hpp
+++ b/include/boost/decimal/detail/emulated128.hpp
@@ -93,21 +93,21 @@ struct uint128
     #ifdef BOOST_DECIMAL_HAS_INT128
     #  if BOOST_DECIMAL_ENDIAN_LITTLE_BYTE
 
-    constexpr uint128(boost::int128_type v) noexcept :  // NOLINT : Allow implicit conversions,
-         low {static_cast<std::uint64_t>(static_cast<boost::uint128_type>(v) & ~UINT64_C(0))},
+    constexpr uint128(boost::decimal::detail::int128_t v) noexcept :  // NOLINT : Allow implicit conversions,
+         low {static_cast<std::uint64_t>(static_cast<boost::decimal::detail::int128_t>(v) & ~UINT64_C(0))},
          high {static_cast<std::uint64_t>(v >> 64)} {}
 
-    constexpr uint128(boost::uint128_type v) noexcept : // NOLINT : Allow implicit conversions
+    constexpr uint128(boost::decimal::detail::uint128_t v) noexcept : // NOLINT : Allow implicit conversions
         low {static_cast<std::uint64_t>(v & ~UINT64_C(0))},
         high {static_cast<std::uint64_t>(v >> 64)} {}
 
     #  else
 
-    constexpr uint128(boost::int128_type v) noexcept :  // NOLINT : Allow implicit conversions,
+    constexpr uint128(boost::decimal::detail::int128_t v) noexcept :  // NOLINT : Allow implicit conversions,
          high {static_cast<std::uint64_t>(v >> 64)},
-         low {static_cast<std::uint64_t>(static_cast<boost::uint128_type>(v) & ~UINT64_C(0))} {}
+         low {static_cast<std::uint64_t>(static_cast<boost::decimal::detail::uint128_t>(v) & ~UINT64_C(0))} {}
 
-    constexpr uint128(boost::uint128_type v) noexcept : // NOLINT : Allow implicit conversions
+    constexpr uint128(boost::decimal::detail::uint128_t v) noexcept : // NOLINT : Allow implicit conversions
         high {static_cast<std::uint64_t>(v >> 64)},
         low {static_cast<std::uint64_t>(v & ~UINT64_C(0))}{}
         
@@ -135,8 +135,8 @@ struct uint128
     UNSIGNED_ASSIGNMENT_OPERATOR(unsigned long long)    // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr auto operator=(const boost::int128_type&  v) noexcept -> uint128& { *this = uint128(v); return *this; }
-    constexpr auto operator=(const boost::uint128_type& v) noexcept -> uint128& { *this = uint128(v); return *this; }
+    constexpr auto operator=(const boost::decimal::detail::int128_t&  v) noexcept -> uint128& { *this = uint128(v); return *this; }
+    constexpr auto operator=(const boost::decimal::detail::uint128_t& v) noexcept -> uint128& { *this = uint128(v); return *this; }
     #endif
 
     constexpr uint128& operator=(const uint128&) noexcept = default;
@@ -202,8 +202,8 @@ struct uint128
     UNSIGNED_INTEGER_OPERATOR_EQUAL(unsigned long long) // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator==(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return lhs == uint128(rhs); }
-    constexpr friend auto operator==(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return lhs == uint128(rhs); }
+    constexpr friend auto operator==(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return lhs == uint128(rhs); }
+    constexpr friend auto operator==(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return lhs == uint128(rhs); }
     #endif
 
     constexpr friend auto operator==(uint128 lhs, uint128 rhs) noexcept -> bool;
@@ -227,8 +227,8 @@ struct uint128
     INTEGER_OPERATOR_NOTEQUAL(unsigned long long)   // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator!=(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return !(lhs == rhs); }
-    constexpr friend auto operator!=(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return !(lhs == rhs); }
+    constexpr friend auto operator!=(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return !(lhs == rhs); }
+    constexpr friend auto operator!=(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return !(lhs == rhs); }
     #endif
 
     constexpr friend auto operator!=(uint128 lhs, uint128 rhs) noexcept -> bool;
@@ -252,8 +252,8 @@ struct uint128
     UNSIGNED_INTEGER_OPERATOR_LESS_THAN(unsigned long long)     // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator<(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return lhs < uint128(rhs); }
-    constexpr friend auto operator<(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return lhs < uint128(rhs); }
+    constexpr friend auto operator<(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return lhs < uint128(rhs); }
+    constexpr friend auto operator<(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return lhs < uint128(rhs); }
     #endif
 
     constexpr friend auto operator<(uint128 lhs, uint128 rhs) noexcept -> bool;
@@ -278,8 +278,8 @@ struct uint128
     UNSIGNED_INTEGER_OPERATOR_LESS_THAN_OR_EQUAL_TO(unsigned long long)     // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator<=(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return lhs <= uint128(rhs); }
-    constexpr friend auto operator<=(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return lhs <= uint128(rhs); }
+    constexpr friend auto operator<=(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return lhs <= uint128(rhs); }
+    constexpr friend auto operator<=(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return lhs <= uint128(rhs); }
     #endif
 
     constexpr friend auto operator<=(uint128 lhs, uint128 rhs) noexcept -> bool ;
@@ -304,8 +304,8 @@ struct uint128
     UNSIGNED_INTEGER_OPERATOR_GREATER_THAN(unsigned long long)      // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator>(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return lhs > uint128(rhs); }
-    constexpr friend auto operator>(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return lhs > uint128(rhs); }
+    constexpr friend auto operator>(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return lhs > uint128(rhs); }
+    constexpr friend auto operator>(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return lhs > uint128(rhs); }
     #endif
 
     constexpr friend auto operator>(uint128 lhs, uint128 rhs) noexcept -> bool ;
@@ -330,8 +330,8 @@ struct uint128
     UNSIGNED_INTEGER_OPERATOR_GREATER_THAN_OR_EQUAL_TO(unsigned long long)      // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator>=(uint128 lhs, boost::int128_type  rhs) noexcept -> bool { return lhs >= uint128(rhs); }
-    constexpr friend auto operator>=(uint128 lhs, boost::uint128_type rhs) noexcept -> bool { return lhs >= uint128(rhs); }
+    constexpr friend auto operator>=(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> bool { return lhs >= uint128(rhs); }
+    constexpr friend auto operator>=(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> bool { return lhs >= uint128(rhs); }
     #endif
 
     constexpr friend auto operator>=(uint128 lhs, uint128 rhs) noexcept -> bool;
@@ -360,8 +360,8 @@ struct uint128
     INTEGER_BINARY_OPERATOR_OR(unsigned long long)  // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator|(uint128 lhs, boost::int128_type  rhs) noexcept -> uint128 { return lhs | uint128(rhs); }
-    constexpr friend auto operator|(uint128 lhs, boost::uint128_type rhs) noexcept -> uint128 { return lhs | uint128(rhs); }
+    constexpr friend auto operator|(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> uint128 { return lhs | uint128(rhs); }
+    constexpr friend auto operator|(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> uint128 { return lhs | uint128(rhs); }
     #endif
 
     constexpr friend auto operator|(uint128 lhs, uint128 rhs) noexcept -> uint128;
@@ -386,8 +386,8 @@ struct uint128
     INTEGER_BINARY_OPERATOR_AND(unsigned long long)     // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator&(uint128 lhs, boost::int128_type  rhs) noexcept -> uint128 { return lhs & uint128(rhs); }
-    constexpr friend auto operator&(uint128 lhs, boost::uint128_type rhs) noexcept -> uint128 { return lhs & uint128(rhs); }
+    constexpr friend auto operator&(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> uint128 { return lhs & uint128(rhs); }
+    constexpr friend auto operator&(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> uint128 { return lhs & uint128(rhs); }
     #endif
 
     constexpr friend auto operator&(uint128 lhs, uint128 rhs) noexcept-> uint128;
@@ -412,8 +412,8 @@ struct uint128
     INTEGER_BINARY_OPERATOR_XOR(unsigned long long)     // NOLINT
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    constexpr friend auto operator^(uint128 lhs, boost::int128_type  rhs) noexcept -> uint128 { return lhs ^ uint128(rhs); }
-    constexpr friend auto operator^(uint128 lhs, boost::uint128_type rhs) noexcept -> uint128 { return lhs ^ uint128(rhs); }
+    constexpr friend auto operator^(uint128 lhs, boost::decimal::detail::int128_t  rhs) noexcept -> uint128 { return lhs ^ uint128(rhs); }
+    constexpr friend auto operator^(uint128 lhs, boost::decimal::detail::uint128_t rhs) noexcept -> uint128 { return lhs ^ uint128(rhs); }
     #endif
 
     constexpr friend auto operator^(uint128 lhs, uint128 rhs) noexcept -> uint128;
@@ -1047,7 +1047,7 @@ constexpr auto umul128(std::uint64_t x, std::uint64_t y) noexcept -> uint128
 {
     #if defined(BOOST_DECIMAL_HAS_INT128)
 
-    auto result = static_cast<boost::uint128_type>(x) * static_cast<boost::uint128_type>(y);
+    auto result = static_cast<boost::decimal::detail::uint128_t>(x) * static_cast<boost::decimal::detail::uint128_t>(y);
     return {static_cast<std::uint64_t>(result >> 64), static_cast<std::uint64_t>(result)};
 
     #else
@@ -1074,7 +1074,7 @@ constexpr auto umul128_upper64(std::uint64_t x, std::uint64_t y) noexcept -> std
 {
     #if defined(BOOST_DECIMAL_HAS_INT128)
     
-    auto result = static_cast<boost::uint128_type>(x) * static_cast<boost::uint128_type>(y);
+    auto result = static_cast<boost::decimal::detail::uint128_t>(x) * static_cast<boost::decimal::detail::uint128_t>(y);
     return static_cast<std::uint64_t>(result >> 64);
     
     #else

--- a/include/boost/decimal/detail/emulated256.hpp
+++ b/include/boost/decimal/detail/emulated256.hpp
@@ -533,7 +533,7 @@ constexpr uint256_t umul256(const T &x, const uint128 &y) noexcept
     static_assert(sizeof(T) == 16 && (!std::numeric_limits<T>::is_signed
             #ifdef BOOST_DECIMAL_HAS_INT128
             // May not have numeric_limits specialization without gnu mode
-                                      || std::is_same<T, boost::uint128_type>::value
+                                      || std::is_same<T, uint128_t>::value
             #endif
     ), "This function is only for 128-bit unsigned types");
 

--- a/include/boost/decimal/detail/from_chars_integer_impl.hpp
+++ b/include/boost/decimal/detail/from_chars_integer_impl.hpp
@@ -82,7 +82,7 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
     auto next = first;
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, boost::int128_type>::value || std::is_signed<Integer>::value)
+    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, int128_t>::value || std::is_signed<Integer>::value)
     #else
     BOOST_DECIMAL_IF_CONSTEXPR (std::is_signed<Integer>::value)
     #endif
@@ -97,7 +97,7 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
         }
 
         #ifdef BOOST_DECIMAL_HAS_INT128
-        BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, boost::int128_type>::value)
+        BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, int128_t>::value)
         {
             overflow_value = BOOST_DECIMAL_INT128_MAX;
             max_digit = BOOST_DECIMAL_INT128_MAX;
@@ -123,7 +123,7 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
         }
         
         #ifdef BOOST_DECIMAL_HAS_INT128
-        BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, boost::uint128_type>::value)
+        BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, uint128_t>::value)
         {
             overflow_value = BOOST_DECIMAL_UINT128_MAX;
             max_digit = BOOST_DECIMAL_UINT128_MAX;
@@ -137,7 +137,7 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
     }
 
     #ifdef BOOST_DECIMAL_HAS_INT128
-    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, boost::int128_type>::value)
+    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, int128_t>::value)
     {
         overflow_value /= unsigned_base;
         max_digit %= unsigned_base;
@@ -211,7 +211,7 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
 
     value = static_cast<Integer>(result);
     #ifdef BOOST_DECIMAL_HAS_INT128
-    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, boost::int128_type>::value || std::is_signed<Integer>::value)
+    BOOST_DECIMAL_IF_CONSTEXPR (std::is_same<Integer, int128_t>::value || std::is_signed<Integer>::value)
     #else
     BOOST_DECIMAL_IF_CONSTEXPR (std::is_signed<Integer>::value)
     #endif

--- a/include/boost/decimal/detail/from_chars_integer_impl.hpp
+++ b/include/boost/decimal/detail/from_chars_integer_impl.hpp
@@ -78,7 +78,8 @@ constexpr auto from_chars_integer_impl(const char* first, const char* last, Inte
 
     // Strip sign if the type is signed
     // Negative sign will be appended at the end of parsing
-    BOOST_DECIMAL_ATTRIBUTE_UNUSED bool is_negative = false;
+    bool is_negative = false;
+    static_cast<void>(is_negative);
     auto next = first;
 
     #ifdef BOOST_DECIMAL_HAS_INT128

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -159,7 +159,7 @@ constexpr auto num_digits(std::uint64_t x) noexcept -> int
     return 1;
 }
 
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
 # pragma warning(push)
 # pragma warning(disable: 4307) // MSVC 14.1 warns of intergral constant overflow
 #endif
@@ -215,7 +215,7 @@ constexpr int num_digits(const uint256_t& x) noexcept
     return 1;
 }
 
-#ifdef BOOST_MSVC
+#ifdef _MSC_VER
 # pragma warning(pop)
 #endif
 

--- a/include/boost/decimal/detail/parser.hpp
+++ b/include/boost/decimal/detail/parser.hpp
@@ -46,7 +46,7 @@ constexpr auto from_chars_dispatch(const char* first, const char* last, uint128&
 #endif
 
 #ifdef BOOST_DECIMAL_HAS_INT128
-auto from_chars_dispatch(const char* first, const char* last, boost::uint128_type& value, int base) noexcept -> from_chars_result
+auto from_chars_dispatch(const char* first, const char* last, uint128_t& value, int base) noexcept -> from_chars_result
 {
     return boost::decimal::detail::from_chars128(first, last, value, base);
 }

--- a/test/test_decimal32.cpp
+++ b/test/test_decimal32.cpp
@@ -305,7 +305,7 @@ void test_subtraction()
     BOOST_TEST(isnan(qnan_val - inf_val));
 
     // Why does MSVC 14.1 warn about unary minus but nothing else does?
-    #ifdef BOOST_MSVC
+    #ifdef _MSC_VER
     #  pragma warning(push)
     #  pragma warning(disable: 4146)
     #endif
@@ -314,7 +314,7 @@ void test_subtraction()
     constexpr decimal32 lowest_val(std::numeric_limits<decimal32>::lowest());
     BOOST_TEST(isinf(lowest_val - one));
 
-    #ifdef BOOST_MSVC
+    #ifdef _MSC_VER
     #  pragma warning(pop)
     #endif
 }


### PR DESCRIPTION
Was only used for attribute we had a backup for and the type of builtin 128 integers