### PR TITLE
Fix for `to_chars` with specified precision and `chars_format::fixed`

### DIFF
--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -277,6 +277,11 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
     *(first + 1) = '.';
     first = r.ptr;
 
+    if (precision == 0)
+    {
+        --first;
+    }
+
     // Strip trailing zeros in general mode
     if (fmt == chars_format::general)
     {

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -349,11 +349,13 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
         --buffer_size;
     }
 
-    int num_dig = 0;
+    int num_dig = num_digits(significand);
     bool append_zeros = false;
+    int integer_digits = num_dig + exponent;
+    num_dig -= integer_digits - 1;
+
     if (precision != -1)
     {
-        num_dig = num_digits(significand);
         if (num_dig >= precision + 2)
         {
             while (num_dig > precision + 2)
@@ -418,7 +420,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
             abs_value /= 10;
         }
     }
-    else
+    else if (precision != 0)
     {
         #ifdef BOOST_DECIMAL_DEBUG_FIXED
         std::cerr << std::setprecision(std::numeric_limits<Real>::digits10) << "Value: " << value
@@ -427,7 +429,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
                   << "\n  exp: " << exponent << std::endl;
         #endif
 
-        const auto offset_bytes = static_cast<std::size_t>(-exponent - num_dig);
+        const auto offset_bytes = static_cast<std::size_t>(integer_digits);
 
         boost::decimal::detail::memmove(first + 2 + static_cast<std::size_t>(is_neg) + offset_bytes,
                                         first + static_cast<std::size_t>(is_neg),

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -453,7 +453,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
     }
 
     const auto current_fractional_digits = r.ptr - output_start - integer_digits - 1;
-    if (current_fractional_digits < precision)
+    if (current_fractional_digits < precision && fmt != chars_format::general)
     {
         append_zeros = true;
     }

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -349,23 +349,25 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
         --buffer_size;
     }
 
+    const char* output_start = first;
+
     int num_dig = num_digits(significand);
     bool append_zeros = false;
     int integer_digits = num_dig + exponent;
-    num_dig -= integer_digits - 1;
+    num_dig -= integer_digits;
 
     if (precision != -1)
     {
-        if (num_dig >= precision + 2)
+        if (num_dig >= precision + 1)
         {
-            while (num_dig > precision + 2)
+            while (num_dig > precision + 1)
             {
                 significand /= 10;
                 ++exponent;
                 --num_dig;
             }
 
-            if (num_dig == precision + 2)
+            if (num_dig == precision + 1)
             {
                 --num_dig;
                 exponent += fenv_round(significand);
@@ -404,7 +406,11 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
     }
 
     // Bounds check again
-    if (abs_value >= 1)
+    if (precision == 0)
+    {
+        return {r.ptr, std::errc()};
+    }
+    else if (abs_value >= 1)
     {
         if (exponent < 0 && -exponent < buffer_size)
         {
@@ -420,7 +426,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
             abs_value /= 10;
         }
     }
-    else if (precision != 0)
+    else
     {
         #ifdef BOOST_DECIMAL_DEBUG_FIXED
         std::cerr << std::setprecision(std::numeric_limits<Real>::digits10) << "Value: " << value
@@ -438,18 +444,23 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
         boost::decimal::detail::memcpy(first + static_cast<std::size_t>(is_neg), "0.", 2U);
         first += 2;
         r.ptr += 2;
+    }
 
-        while (num_dig < -exponent)
-        {
-            *first++ = '0';
-            ++num_dig;
-            ++r.ptr;
-        }
+    // The leading 0 is an integer digit now that we need to account for
+    if (integer_digits == 0)
+    {
+        ++integer_digits;
+    }
+
+    const auto current_fractional_digits = r.ptr - output_start - integer_digits - 1;
+    if (current_fractional_digits < precision)
+    {
+        append_zeros = true;
     }
 
     if (append_zeros)
     {
-        const auto zeros_inserted = static_cast<std::size_t>(precision - num_dig + 1);
+        const auto zeros_inserted = static_cast<std::size_t>(precision - current_fractional_digits);
 
         if (r.ptr + zeros_inserted > last)
         {

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -275,7 +275,7 @@ void zero_test()
 
 // See: https://github.com/cppalliance/decimal/issues/434
 template <typename T>
-void test_434()
+void test_434_fixed()
 {
     constexpr T test_zero_point_three {3, -1};
 
@@ -292,6 +292,27 @@ void test_434()
     test_value(test_zero_point_three, "0.3000000000", chars_format::fixed, 10);
     test_value(test_zero_point_three, "0.30000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
 
+    constexpr T test_one_and_quarter {125, -2};
+
+    test_value(test_one_and_quarter, "1", chars_format::fixed, 0);
+    test_value(test_one_and_quarter, "1.3", chars_format::fixed, 1);
+    test_value(test_one_and_quarter, "1.25", chars_format::fixed, 2);
+    test_value(test_one_and_quarter, "1.250", chars_format::fixed, 3);
+    test_value(test_one_and_quarter, "1.2500", chars_format::fixed, 4);
+    test_value(test_one_and_quarter, "1.25000", chars_format::fixed, 5);
+    test_value(test_one_and_quarter, "1.250000", chars_format::fixed, 6);
+    test_value(test_one_and_quarter, "1.2500000", chars_format::fixed, 7);
+    test_value(test_one_and_quarter, "1.25000000", chars_format::fixed, 8);
+    test_value(test_one_and_quarter, "1.250000000", chars_format::fixed, 9);
+    test_value(test_one_and_quarter, "1.2500000000", chars_format::fixed, 10);
+    test_value(test_one_and_quarter, "1.25000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
+}
+
+template <typename T>
+void test_434_scientific()
+{
+    constexpr T test_zero_point_three {3, -1};
+
     test_value(test_zero_point_three, "3e-01", chars_format::scientific, 0);
     test_value(test_zero_point_three, "3.0e-01", chars_format::scientific, 1);
     test_value(test_zero_point_three, "3.00e-01", chars_format::scientific, 2);
@@ -304,8 +325,6 @@ void test_434()
     test_value(test_zero_point_three, "3.000000000e-01", chars_format::scientific, 9);
     test_value(test_zero_point_three, "3.0000000000e-01", chars_format::scientific, 10);
     test_value(test_zero_point_three, "3.00000000000000000000000000000000000000000000000000e-01", chars_format::scientific, 50);
-
-    //constexpr T test_one_and_quarter {125, -2};
 }
 
 int main()
@@ -331,7 +350,8 @@ int main()
     zero_test<decimal32>();
     zero_test<decimal64>();
 
-    test_434<decimal32>();
+    test_434_fixed<decimal32>();
+    test_434_fixed<decimal64>();
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
     test_non_finite_values<decimal128>();

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -306,6 +306,21 @@ void test_434_fixed()
     test_value(test_one_and_quarter, "1.250000000", chars_format::fixed, 9);
     test_value(test_one_and_quarter, "1.2500000000", chars_format::fixed, 10);
     test_value(test_one_and_quarter, "1.25000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
+
+    constexpr T tweleve_and_half {125, -1};
+
+    test_value(tweleve_and_half, "13", chars_format::fixed, 0);
+    test_value(tweleve_and_half, "12.5", chars_format::fixed, 1);
+    test_value(tweleve_and_half, "12.50", chars_format::fixed, 2);
+    test_value(tweleve_and_half, "12.500", chars_format::fixed, 3);
+    test_value(tweleve_and_half, "12.5000", chars_format::fixed, 4);
+    test_value(tweleve_and_half, "12.50000", chars_format::fixed, 5);
+    test_value(tweleve_and_half, "12.500000", chars_format::fixed, 6);
+    test_value(tweleve_and_half, "12.5000000", chars_format::fixed, 7);
+    test_value(tweleve_and_half, "12.50000000", chars_format::fixed, 8);
+    test_value(tweleve_and_half, "12.500000000", chars_format::fixed, 9);
+    test_value(tweleve_and_half, "12.5000000000", chars_format::fixed, 10);
+    test_value(tweleve_and_half, "12.50000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
 }
 
 template <typename T>

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -376,6 +376,7 @@ int main()
     test_precision<decimal128>();
     test_buffer_overflow<decimal128>();
     zero_test<decimal128>();
+    test_434_fixed<decimal128>();
     #endif
 
     return boost::report_errors();

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -273,6 +273,41 @@ void zero_test()
     test_value(val, "0.00000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
 }
 
+// See: https://github.com/cppalliance/decimal/issues/434
+template <typename T>
+void test_434()
+{
+    constexpr T test_zero_point_three {3, -1};
+
+    test_value(test_zero_point_three, "0", chars_format::fixed, 0);
+    test_value(test_zero_point_three, "0.3", chars_format::fixed, 1);
+    test_value(test_zero_point_three, "0.30", chars_format::fixed, 2);
+    test_value(test_zero_point_three, "0.300", chars_format::fixed, 3);
+    test_value(test_zero_point_three, "0.3000", chars_format::fixed, 4);
+    test_value(test_zero_point_three, "0.30000", chars_format::fixed, 5);
+    test_value(test_zero_point_three, "0.300000", chars_format::fixed, 6);
+    test_value(test_zero_point_three, "0.3000000", chars_format::fixed, 7);
+    test_value(test_zero_point_three, "0.30000000", chars_format::fixed, 8);
+    test_value(test_zero_point_three, "0.300000000", chars_format::fixed, 9);
+    test_value(test_zero_point_three, "0.3000000000", chars_format::fixed, 10);
+    test_value(test_zero_point_three, "0.30000000000000000000000000000000000000000000000000", chars_format::fixed, 50);
+
+    test_value(test_zero_point_three, "3e-01", chars_format::scientific, 0);
+    test_value(test_zero_point_three, "3.0e-01", chars_format::scientific, 1);
+    test_value(test_zero_point_three, "3.00e-01", chars_format::scientific, 2);
+    test_value(test_zero_point_three, "3.000e-01", chars_format::scientific, 3);
+    test_value(test_zero_point_three, "3.0000e-01", chars_format::scientific, 4);
+    test_value(test_zero_point_three, "3.00000e-01", chars_format::scientific, 5);
+    test_value(test_zero_point_three, "3.000000e-01", chars_format::scientific, 6);
+    test_value(test_zero_point_three, "3.0000000e-01", chars_format::scientific, 7);
+    test_value(test_zero_point_three, "3.00000000e-01", chars_format::scientific, 8);
+    test_value(test_zero_point_three, "3.000000000e-01", chars_format::scientific, 9);
+    test_value(test_zero_point_three, "3.0000000000e-01", chars_format::scientific, 10);
+    test_value(test_zero_point_three, "3.00000000000000000000000000000000000000000000000000e-01", chars_format::scientific, 50);
+
+    //constexpr T test_one_and_quarter {125, -2};
+}
+
 int main()
 {
     test_non_finite_values<decimal32>();
@@ -295,6 +330,8 @@ int main()
 
     zero_test<decimal32>();
     zero_test<decimal64>();
+
+    test_434<decimal32>();
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
     test_non_finite_values<decimal128>();


### PR DESCRIPTION
One-half of the solution to #434 