### PR TITLE
Fix `to_chars` with specified precision and `chars_format::scientific`

### DIFF
--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -259,9 +259,16 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
         return r; // LCOV_EXCL_LINE
     }
 
+    const auto current_digits = r.ptr - (first + 1) - 1;
+
+    if (current_digits < precision && fmt != chars_format::general)
+    {
+        append_zeros = true;
+    }
+
     if (append_zeros)
     {
-        const auto zeros_inserted {static_cast<std::size_t>(precision - significand_digits + 1)};
+        const auto zeros_inserted {static_cast<std::size_t>(precision - current_digits)};
 
         if (r.ptr + zeros_inserted > last)
         {

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -399,6 +399,7 @@ int main()
     test_434_fixed<decimal64>();
 
     test_434_scientific<decimal32>();
+    test_434_scientific<decimal64>();
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
     test_non_finite_values<decimal128>();
@@ -409,6 +410,7 @@ int main()
     test_buffer_overflow<decimal128>();
     zero_test<decimal128>();
     test_434_fixed<decimal128>();
+    test_434_scientific<decimal128>();
     #endif
 
     return boost::report_errors();

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -340,6 +340,36 @@ void test_434_scientific()
     test_value(test_zero_point_three, "3.000000000e-01", chars_format::scientific, 9);
     test_value(test_zero_point_three, "3.0000000000e-01", chars_format::scientific, 10);
     test_value(test_zero_point_three, "3.00000000000000000000000000000000000000000000000000e-01", chars_format::scientific, 50);
+
+    constexpr T test_one_and_quarter {125, -2};
+
+    test_value(test_one_and_quarter, "1e+00", chars_format::scientific, 0);
+    test_value(test_one_and_quarter, "1.3e+00", chars_format::scientific, 1);
+    test_value(test_one_and_quarter, "1.25e+00", chars_format::scientific, 2);
+    test_value(test_one_and_quarter, "1.250e+00", chars_format::scientific, 3);
+    test_value(test_one_and_quarter, "1.2500e+00", chars_format::scientific, 4);
+    test_value(test_one_and_quarter, "1.25000e+00", chars_format::scientific, 5);
+    test_value(test_one_and_quarter, "1.250000e+00", chars_format::scientific, 6);
+    test_value(test_one_and_quarter, "1.2500000e+00", chars_format::scientific, 7);
+    test_value(test_one_and_quarter, "1.25000000e+00", chars_format::scientific, 8);
+    test_value(test_one_and_quarter, "1.250000000e+00", chars_format::scientific, 9);
+    test_value(test_one_and_quarter, "1.2500000000e+00", chars_format::scientific, 10);
+    test_value(test_one_and_quarter, "1.25000000000000000000000000000000000000000000000000e+00", chars_format::scientific, 50);
+
+    constexpr T tweleve_and_half {125, -1};
+
+    test_value(tweleve_and_half, "1e+01", chars_format::scientific, 0);
+    test_value(tweleve_and_half, "1.3e+01", chars_format::scientific, 1);
+    test_value(tweleve_and_half, "1.25e+01", chars_format::scientific, 2);
+    test_value(tweleve_and_half, "1.250e+01", chars_format::scientific, 3);
+    test_value(tweleve_and_half, "1.2500e+01", chars_format::scientific, 4);
+    test_value(tweleve_and_half, "1.25000e+01", chars_format::scientific, 5);
+    test_value(tweleve_and_half, "1.250000e+01", chars_format::scientific, 6);
+    test_value(tweleve_and_half, "1.2500000e+01", chars_format::scientific, 7);
+    test_value(tweleve_and_half, "1.25000000e+01", chars_format::scientific, 8);
+    test_value(tweleve_and_half, "1.250000000e+01", chars_format::scientific, 9);
+    test_value(tweleve_and_half, "1.2500000000e+01", chars_format::scientific, 10);
+    test_value(tweleve_and_half, "1.25000000000000000000000000000000000000000000000000e+01", chars_format::scientific, 50);
 }
 
 int main()
@@ -367,6 +397,8 @@ int main()
 
     test_434_fixed<decimal32>();
     test_434_fixed<decimal64>();
+
+    test_434_scientific<decimal32>();
 
     #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
     test_non_finite_values<decimal128>();


### PR DESCRIPTION
Closes: #434 