### PR TITLE
Fix cbrt and expand testing

### DIFF
--- a/include/boost/decimal/detail/cmath/cbrt.hpp
+++ b/include/boost/decimal/detail/cmath/cbrt.hpp
@@ -21,6 +21,7 @@ template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
 constexpr auto cbrt(T val) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
 {
     constexpr T zero {0, 0};
+    constexpr T one {1, 0};
 
     T result { };
 
@@ -43,56 +44,26 @@ constexpr auto cbrt(T val) noexcept -> std::enable_if_t<detail::is_decimal_float
     {
         result = std::numeric_limits<T>::quiet_NaN();
     }
+    else if (val == one)
+    {
+        result = one;
+    }
     else
     {
-        constexpr T one { 1, 0 };
+        constexpr T epsilon = std::numeric_limits<T>::epsilon() * 100;
+        T error = 1 / epsilon;
 
-        const auto arg_is_gt_one = (val > one);
+        T x = val > 1 ? val / 3 : val * 2; // Initial Guess
 
-        if (arg_is_gt_one || val < one)
+        while (error > epsilon)
         {
-            // TODO(ckormanyos)
-            // TODO(mborland)
-            // This implementation of cube root, although it works, needs optimization.
-            // Using base-2 frexp/ldexp might not be the best, rather use base-10?
+            const T new_x {(2 * x + val / (x * x)) / 3};
 
-            int exp2val { };
-
-            const auto man = frexp(val, &exp2val);
-
-            const auto corrected = (static_cast<unsigned>(exp2val) & 1U) != 0U;
-
-            // TODO(ckormanyos)
-            // Try to find a way to get a better (much better) initial guess.
-
-            if (!corrected)
-            {
-                result = ldexp(man / 3, exp2val / 3);
-            }
-            else
-            {
-                result = ldexp(man, arg_is_gt_one ? --exp2val / 3 : ++exp2val / 3);
-            }
-
-            constexpr auto newton_steps = (sizeof(T) == 4U) ? 5U :
-                                          (sizeof(T) == 8U) ? 6U : 10U;
-
-            for (auto i = 0U; i < newton_steps; ++i)
-            {
-                const auto sqruared_res {result * result};
-                const auto cubed_res {result * sqruared_res};
-                result -= (cubed_res - 3) / (3 * sqruared_res);
-            }
-
-            if (corrected)
-            {
-                result /= numbers::sqrt3_v<T>;
-            }
+            error = fabs(new_x - x);
+            x = new_x;
         }
-        else
-        {
-            result = one;
-        }
+
+        result = x;
     }
 
     return result;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -48,6 +48,7 @@ run test_atan.cpp ;
 run test_atan2.cpp ;
 run test_atanh.cpp ;
 run test_big_uints.cpp ;
+run test_cbrt.cpp ;
 run test_cmath.cpp ;
 run test_constants.cpp ;
 run test_cosh.cpp ;

--- a/test/test_cbrt.cpp
+++ b/test/test_cbrt.cpp
@@ -1,0 +1,126 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/math/special_functions/next.hpp>
+#include <iostream>
+#include <random>
+#include <type_traits>
+
+#if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH) && !defined(_WIN32)
+static constexpr auto N = static_cast<std::size_t>(128U); // Number of trials
+#else
+static constexpr auto N = static_cast<std::size_t>(128U >> 4U); // Number of trials
+#endif
+
+static std::mt19937_64 rng(42);
+
+using namespace boost::decimal;
+
+template <typename Dec>
+void test_random_cbrt()
+{
+    using comp_type = std::conditional_t<std::is_same<Dec, decimal32>::value, float, double>;
+    std::uniform_real_distribution<comp_type> dist(1, 1e3);
+
+    constexpr auto max_iter {std::is_same<Dec, decimal128>::value ? N / 4 : N};
+    for (std::size_t n {}; n < max_iter; ++n)
+    {
+        const auto val1 {dist(rng)};
+        Dec d1 {val1};
+
+        auto ret_val {std::cbrt(val1)};
+        auto ret_dec {static_cast<comp_type>(cbrt(d1))};
+
+        if (!BOOST_TEST(std::abs(boost::math::float_distance(ret_val, ret_dec)) < 15))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << d1
+                      << "\nRet val: " << ret_val
+                      << "\nRet dec: " << ret_dec
+                      << "\nEps: " << boost::math::float_distance(ret_val, ret_dec) << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    std::uniform_real_distribution<comp_type> small_dist(0, 1);
+
+    for (std::size_t n {}; n < max_iter; ++n)
+    {
+        const auto val1 {small_dist(rng)};
+        Dec d1 {val1};
+
+        auto ret_val {std::cbrt(val1)};
+        auto ret_dec {static_cast<comp_type>(cbrt(d1))};
+
+        if (!BOOST_TEST(std::abs(boost::math::float_distance(ret_val, ret_dec)) < 15))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << d1
+                      << "\nRet val: " << ret_val
+                      << "\nRet dec: " << ret_dec
+                      << "\nEps: " << boost::math::float_distance(ret_val, ret_dec) << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+
+    Dec inf {std::numeric_limits<Dec>::infinity() * static_cast<int>(dist(rng))};
+    Dec nan {std::numeric_limits<Dec>::quiet_NaN() * static_cast<int>(dist(rng))};
+    Dec zero {0 * static_cast<int>(dist(rng))};
+    Dec neg_num {-static_cast<int>(dist(rng))};
+    BOOST_TEST(isinf(cbrt(inf)));
+    BOOST_TEST(isnan(cbrt(-inf)));
+    BOOST_TEST(isnan(cbrt(nan)));
+    BOOST_TEST(isnan(cbrt(-nan)));
+    BOOST_TEST_EQ(cbrt(zero), zero);
+    BOOST_TEST(isnan(cbrt(neg_num)));
+}
+
+template <typename T>
+void test_spot(T val, T expected_result)
+{
+    using comp_type = std::conditional_t<std::is_same<T, decimal32>::value, float, double>;
+
+    const T val_cbrt {cbrt(val)};
+
+    if (!BOOST_TEST(std::abs(boost::math::float_distance(static_cast<comp_type>(val_cbrt), static_cast<comp_type>(expected_result))) < 15))
+    {
+        // LCOV_EXCL_START
+        std::cerr << "   Val: " << val
+                  << "\n  Cbrt: " << val_cbrt
+                  << "\nExpect: " << expected_result
+                  << "\nEps: " << boost::math::float_distance(static_cast<comp_type>(val_cbrt), static_cast<comp_type>(expected_result)) << std::endl;
+        // LCOV_EXCL_STOP
+    }
+}
+
+// https://github.com/cppalliance/decimal/issues/440
+template <typename T>
+void test_spots()
+{
+    test_spot(T{8}, T{2});
+    test_spot(T{27}, T{3});
+    test_spot(T{64}, T{4});
+    test_spot(T{125}, T{5});
+    test_spot(T{216}, T{6});
+}
+
+int main()
+{
+    test_random_cbrt<decimal32>();
+    test_random_cbrt<decimal64>();
+
+    test_spots<decimal32>();
+    test_spots<decimal64>();
+
+    #ifndef BOOST_DECIMAL_REDUCE_TEST_DEPTH
+    test_random_cbrt<decimal128>();
+    test_spots<decimal128>();
+    #endif
+
+    return boost::report_errors();
+}

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -629,45 +629,6 @@ void test_sqrt()
 }
 
 template <typename Dec>
-void test_cbrt()
-{
-    using comp_type = std::conditional_t<std::is_same<Dec, decimal32>::value, float, double>;
-    std::uniform_real_distribution<comp_type> dist(0, 1e5);
-
-    constexpr auto max_iter {std::is_same<Dec, decimal128>::value ? N / 4 : N};
-    for (std::size_t n {}; n < max_iter; ++n)
-    {
-        const auto val1 {dist(rng)};
-        Dec d1 {val1};
-
-        auto ret_val {std::cbrt(val1)};
-        auto ret_dec {static_cast<comp_type>(cbrt(d1))};
-
-        if (!BOOST_TEST(boost::math::float_distance(ret_val, ret_dec) < 15))
-        {
-            // LCOV_EXCL_START
-            std::cerr << "Val 1: " << val1
-                      << "\nDec 1: " << d1
-                      << "\nRet val: " << ret_val
-                      << "\nRet dec: " << ret_dec
-                      << "\nEps: " << boost::math::float_distance(ret_val, ret_dec) << std::endl;
-            // LCOV_EXCL_STOP
-        }
-    }
-
-    Dec inf {std::numeric_limits<Dec>::infinity() * static_cast<int>(dist(rng))};
-    Dec nan {std::numeric_limits<Dec>::quiet_NaN() * static_cast<int>(dist(rng))};
-    Dec zero {0 * static_cast<int>(dist(rng))};
-    Dec neg_num {-static_cast<int>(dist(rng))};
-    BOOST_TEST(isinf(cbrt(inf)));
-    BOOST_TEST(isnan(cbrt(-inf)));
-    BOOST_TEST(isnan(cbrt(nan)));
-    BOOST_TEST(isnan(cbrt(-nan)));
-    BOOST_TEST_EQ(cbrt(zero), zero);
-    BOOST_TEST(isnan(cbrt(neg_num)));
-}
-
-template <typename Dec>
 void test_two_val_hypot()
 {
     std::uniform_real_distribution<float> dist(1.0F, 1e5F);
@@ -1603,9 +1564,6 @@ int main()
 
     test_sqrt<decimal32>();
     test_sqrt<decimal64>();
-
-    test_cbrt<decimal32>();
-    test_cbrt<decimal64>();
 
     test_two_val_hypot<decimal32>();
     test_three_val_hypot<decimal32>();


### PR DESCRIPTION
Fixes: #440 

@ckormanyos I simplified the step and initial guess which has this working correctly. I still think it's worth investigating a much better initial guess if that's something you still want to pursue. 

I am going to keep separating tests out of the giant test_cmath file because I found this was tested incorrectly (wasn't taking the abs of the float distance) and it's easier to run GDB through smaller files.