### PR TITLE
Improve use of concepts for cmath functions

### DIFF
--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -213,11 +213,13 @@ private:
 
     friend constexpr auto d128_mod_impl(decimal128 lhs, decimal128 rhs, const decimal128& q, decimal128& r) noexcept -> void;
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto ilogb(T d) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>;
+    template <typename T>
+    friend constexpr auto ilogb(T d) noexcept
+        BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, int);
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto logb(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>;
+    template <typename T>
+    friend constexpr auto logb(T num) noexcept
+        BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T);
 
 public:
     // 3.2.4.1 construct/copy/destroy

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -161,11 +161,13 @@ private:
     friend constexpr auto div_impl(decimal32 lhs, decimal32 rhs, decimal32& q, decimal32& r) noexcept -> void;
     friend constexpr auto mod_impl(decimal32 lhs, decimal32 rhs, const decimal32& q, decimal32& r) noexcept -> void;
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto ilogb(T d) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>;
+    template <typename T>
+    friend constexpr auto ilogb(T d) noexcept
+        BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, int);
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto logb(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>;
+    template <typename T>
+    friend constexpr auto logb(T num) noexcept
+        BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T);
 
     // Debug bit pattern
     friend constexpr auto from_bits(std::uint32_t bits) noexcept -> decimal32;

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -204,11 +204,13 @@ private:
 
     friend constexpr auto d64_mod_impl(decimal64 lhs, decimal64 rhs, const decimal64& q, decimal64& r) noexcept -> void;
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto ilogb(T d) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>;
+    template <typename T>
+    friend constexpr auto ilogb(T d) noexcept
+        BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, int);
 
-    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-    friend constexpr auto logb(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>;
+    template <typename T>
+    friend constexpr auto logb(T num) noexcept
+        BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T);
 
 public:
     // 3.2.3.1 construct/copy/destroy

--- a/include/boost/decimal/detail/cmath/abs.hpp
+++ b/include/boost/decimal/detail/cmath/abs.hpp
@@ -15,9 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto abs BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T rhs) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return signbit(rhs) ? -rhs : rhs;
 }

--- a/include/boost/decimal/detail/cmath/acos.hpp
+++ b/include/boost/decimal/detail/cmath/acos.hpp
@@ -18,8 +18,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto acos(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto acos(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     if (isnan(x))
     {

--- a/include/boost/decimal/detail/cmath/acosh.hpp
+++ b/include/boost/decimal/detail/cmath/acosh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto acosh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto acosh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/asin.hpp
+++ b/include/boost/decimal/detail/cmath/asin.hpp
@@ -19,8 +19,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto asin(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto asin(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc {fpclassify(x)};
     const auto isneg {signbit(x)};

--- a/include/boost/decimal/detail/cmath/asinh.hpp
+++ b/include/boost/decimal/detail/cmath/asinh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto asinh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto asinh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/assoc_laguerre.hpp
+++ b/include/boost/decimal/detail/cmath/assoc_laguerre.hpp
@@ -19,7 +19,9 @@ namespace decimal {
 
 namespace detail {
 
-template <typename T1, typename T2, typename T3>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T3>
 constexpr auto assoc_laguerre_next(unsigned n, unsigned l, T1 x, T2 Pl, T3 Plm1)
 {
     using promoted_type = promote_args_t<T1, T2, T3>;
@@ -28,8 +30,9 @@ constexpr auto assoc_laguerre_next(unsigned n, unsigned l, T1 x, T2 Pl, T3 Plm1)
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto assoc_laguerre(unsigned n, unsigned m, T x) -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto assoc_laguerre(unsigned n, unsigned m, T x)
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     // Special cases:
     if(m == 0)

--- a/include/boost/decimal/detail/cmath/assoc_legendre.hpp
+++ b/include/boost/decimal/detail/cmath/assoc_legendre.hpp
@@ -26,7 +26,9 @@ namespace decimal {
 
 namespace detail {
 
-template <typename T1, typename T2, typename T3>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T3>
 constexpr auto assoc_legendre_next(unsigned l, unsigned m, T1 x, T2 Pl, T3 Plm1) noexcept
 {
     using result_type = promote_args_t<T1, T2, T3>;
@@ -34,8 +36,9 @@ constexpr auto assoc_legendre_next(unsigned l, unsigned m, T1 x, T2 Pl, T3 Plm1)
 }
 
 // Implement Legendre P and Q polynomials via recurrence:
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr T assoc_legendre_impl(unsigned l, unsigned m, T x, T sin_theta_power) noexcept
+template <typename T>
+constexpr auto assoc_legendre_impl(unsigned l, unsigned m, T x, T sin_theta_power) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     if (x < -1 || x > 1 || l > 128)
     {
@@ -90,8 +93,9 @@ constexpr T assoc_legendre_impl(unsigned l, unsigned m, T x, T sin_theta_power) 
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto assoc_legendre(unsigned n, unsigned m, T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto assoc_legendre(unsigned n, unsigned m, T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return detail::assoc_legendre_impl(n, m, x, pow(1 - x*x, T{m} / 2));
 }

--- a/include/boost/decimal/detail/cmath/atan.hpp
+++ b/include/boost/decimal/detail/cmath/atan.hpp
@@ -158,8 +158,9 @@ constexpr auto atan_huge_impl(T x) noexcept
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto atan(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto atan(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc {fpclassify(x)};
     const auto isneg {signbit(x)};

--- a/include/boost/decimal/detail/cmath/atan2.hpp
+++ b/include/boost/decimal/detail/cmath/atan2.hpp
@@ -36,8 +36,9 @@ template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T> constexpr T pi_constants<T>::th
 } // namespace atan2_detail
 } // namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto atan2(T y, T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpcx {fpclassify(x)};
     const auto fpcy {fpclassify(y)};

--- a/include/boost/decimal/detail/cmath/atanh.hpp
+++ b/include/boost/decimal/detail/cmath/atanh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto atanh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto atanh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/cbrt.hpp
+++ b/include/boost/decimal/detail/cmath/cbrt.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto cbrt(T val) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto cbrt(T val) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
     constexpr T one {1, 0};

--- a/include/boost/decimal/detail/cmath/ceil.hpp
+++ b/include/boost/decimal/detail/cmath/ceil.hpp
@@ -19,9 +19,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto ceil BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     using DivType = std::conditional_t<std::is_same<T, decimal32>::value, std::uint32_t,
                     std::conditional_t<std::is_same<T, decimal64>::value, std::uint64_t, detail::uint128>>;
@@ -68,7 +68,7 @@ constexpr auto ceil BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
     }
     new_sig *= 10;
 
-    return {new_sig, exp_ptr + static_cast<int>(decimal_digits) - 1, is_neg};
+    return T{new_sig, exp_ptr + static_cast<int>(decimal_digits) - 1, is_neg};
 }
 
 } // namespace decimal

--- a/include/boost/decimal/detail/cmath/cos.hpp
+++ b/include/boost/decimal/detail/cmath/cos.hpp
@@ -20,8 +20,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto cos(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto cos(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/cosh.hpp
+++ b/include/boost/decimal/detail/cmath/cosh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto cosh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto cosh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/ellint_1.hpp
+++ b/include/boost/decimal/detail/cmath/ellint_1.hpp
@@ -133,8 +133,9 @@ constexpr auto ellint_f_impl(T phi, T k) noexcept -> T
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto comp_ellint_1(T k) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto comp_ellint_1(T k) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
    return detail::ellint_k_imp(k);
 }

--- a/include/boost/decimal/detail/cmath/erf.hpp
+++ b/include/boost/decimal/detail/cmath/erf.hpp
@@ -753,8 +753,9 @@ constexpr auto erf_impl<decimal128>(decimal128 z, bool invert) noexcept -> decim
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto erf(T z) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto erf(T z) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     // Edge cases
     const auto fp {fpclassify(z)};
@@ -771,8 +772,9 @@ constexpr auto erf(T z) noexcept -> std::enable_if_t<detail::is_decimal_floating
     return detail::erf_impl(z, false);
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto erfc(T z) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto erfc(T z) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     // Edge cases
     const auto fp {fpclassify(z)};

--- a/include/boost/decimal/detail/cmath/exp.hpp
+++ b/include/boost/decimal/detail/cmath/exp.hpp
@@ -18,8 +18,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto exp(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto exp(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/exp2.hpp
+++ b/include/boost/decimal/detail/cmath/exp2.hpp
@@ -12,8 +12,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto exp2(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto exp2(T num) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T two {2, 0};
 

--- a/include/boost/decimal/detail/cmath/expm1.hpp
+++ b/include/boost/decimal/detail/cmath/expm1.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto expm1(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto expm1(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/fabs.hpp
+++ b/include/boost/decimal/detail/cmath/fabs.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto fabs(T a) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto fabs(T a) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return abs(a);
 }

--- a/include/boost/decimal/detail/cmath/fdim.hpp
+++ b/include/boost/decimal/detail/cmath/fdim.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto fdim(T x, T y) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto fdim(T x, T y) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
 

--- a/include/boost/decimal/detail/cmath/floor.hpp
+++ b/include/boost/decimal/detail/cmath/floor.hpp
@@ -20,9 +20,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto floor BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     using DivType = std::conditional_t<std::is_same<T, decimal32>::value, std::uint32_t,
                     std::conditional_t<std::is_same<T, decimal64>::value, std::uint64_t, detail::uint128>>;
@@ -73,7 +73,7 @@ constexpr auto floor BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
         ++new_sig;
     }
 
-    return {new_sig, exp_ptr + static_cast<int>(decimal_digits), is_neg};
+    return T{new_sig, exp_ptr + static_cast<int>(decimal_digits), is_neg};
 }
 
 } // namespace decimal

--- a/include/boost/decimal/detail/cmath/fmax.hpp
+++ b/include/boost/decimal/detail/cmath/fmax.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1, BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
+template <typename T1, typename T2>
 constexpr auto fmax(T1 lhs, T2 rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_TWO(detail::is_decimal_floating_point_v, T1, detail::is_decimal_floating_point_v, T2)
 {
     using promoted_type = detail::promote_args_t<T1, T2>;
 

--- a/include/boost/decimal/detail/cmath/fmin.hpp
+++ b/include/boost/decimal/detail/cmath/fmin.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1, BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
+template <typename T1, typename T2>
 constexpr auto fmin(T1 lhs, T2 rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_TWO(detail::is_decimal_floating_point_v, T1, detail::is_decimal_floating_point_v, T2)
 {
     using promoted_type = detail::promote_args_t<T1, T2>;
 

--- a/include/boost/decimal/detail/cmath/fmod.hpp
+++ b/include/boost/decimal/detail/cmath/fmod.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto fmod(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto fmod(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return lhs % rhs;
 }

--- a/include/boost/decimal/detail/cmath/fpclassify.hpp
+++ b/include/boost/decimal/detail/cmath/fpclassify.hpp
@@ -15,9 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto fpclassify BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T rhs) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, int)
 {
     constexpr T zero {0, 0};
 

--- a/include/boost/decimal/detail/cmath/frexp.hpp
+++ b/include/boost/decimal/detail/cmath/frexp.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto frexp(T v, int* expon) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto frexp(T v, int* expon) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     // This implementation of frexp follows closely that of eval_frexp
     // in Boost.Multiprecision's cpp_dec_float template class.

--- a/include/boost/decimal/detail/cmath/hermite.hpp
+++ b/include/boost/decimal/detail/cmath/hermite.hpp
@@ -18,7 +18,9 @@ namespace decimal {
 
 namespace detail {
 
-template <typename T1, typename T2, typename T3>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T3>
 constexpr auto hermite_next(unsigned n, T1 x, T2 Hn, T3 Hnm1)
 {
     using promoted_type = promote_args_t<T1, T2, T3>;
@@ -27,8 +29,9 @@ constexpr auto hermite_next(unsigned n, T1 x, T2 Hn, T3 Hnm1)
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto hermite(unsigned n, T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto hermite(unsigned n, T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T p0 {UINT64_C(1)};
     T p1 {UINT64_C(2) * x};

--- a/include/boost/decimal/detail/cmath/hypot.hpp
+++ b/include/boost/decimal/detail/cmath/hypot.hpp
@@ -19,7 +19,8 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1, BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
 constexpr auto hypot(T1 x, T2 y) noexcept
 {
     using promoted_type = detail::promote_args_t<T1, T2>;

--- a/include/boost/decimal/detail/cmath/ilogb.hpp
+++ b/include/boost/decimal/detail/cmath/ilogb.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto ilogb(T d) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, int>
+template <typename T>
+constexpr auto ilogb(T d) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, int)
 {
     const auto fpc_d = fpclassify(d);
 

--- a/include/boost/decimal/detail/cmath/isfinite.hpp
+++ b/include/boost/decimal/detail/cmath/isfinite.hpp
@@ -15,9 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 constexpr auto isfinite BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T rhs) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     return !isinf(rhs) && !isnan(rhs);
 }

--- a/include/boost/decimal/detail/cmath/isgreater.hpp
+++ b/include/boost/decimal/detail/cmath/isgreater.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto isgreater(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto isgreater(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     if (isnan(lhs) || isnan(rhs))
     {
@@ -25,8 +26,9 @@ constexpr auto isgreater(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_d
     return lhs > rhs;
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto isgreaterequal(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto isgreaterequal(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     if (isnan(lhs) || isnan(rhs))
     {

--- a/include/boost/decimal/detail/cmath/isless.hpp
+++ b/include/boost/decimal/detail/cmath/isless.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto isless(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto isless(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     if (isnan(lhs) || isnan(rhs))
     {
@@ -25,8 +26,9 @@ constexpr auto isless(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_deci
     return lhs < rhs;
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto islessequal(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto islessequal(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     if (isnan(lhs) || isnan(rhs))
     {
@@ -36,8 +38,9 @@ constexpr auto islessequal(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is
     return lhs <= rhs;
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto islessgreater(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto islessgreater(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     if (isnan(lhs) || isnan(rhs))
     {

--- a/include/boost/decimal/detail/cmath/isunordered.hpp
+++ b/include/boost/decimal/detail/cmath/isunordered.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto isunordered(T lhs, T rhs) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, bool>
+template <typename T>
+constexpr auto isunordered(T lhs, T rhs) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, bool)
 {
     return isnan(lhs) || isnan(rhs);
 }

--- a/include/boost/decimal/detail/cmath/laguerre.hpp
+++ b/include/boost/decimal/detail/cmath/laguerre.hpp
@@ -18,7 +18,9 @@ namespace decimal {
 
 namespace detail {
 
-template <typename T1, typename T2, typename T3>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T3>
 constexpr auto laguerre_next(unsigned n, T1 x, T2 Ln, T3 Lnm1)
 {
     using promoted_type = promote_args_t<T1, T2, T3>;
@@ -28,8 +30,9 @@ constexpr auto laguerre_next(unsigned n, T1 x, T2 Ln, T3 Lnm1)
 } //namespace detail
 
 // Implement Laguerre polynomials via recurrence:
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto laguerre(unsigned n, T x) -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto laguerre(unsigned n, T x)
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T p0 {UINT64_C(1)};
     T p1 {UINT64_C(1) - x};

--- a/include/boost/decimal/detail/cmath/ldexp.hpp
+++ b/include/boost/decimal/detail/cmath/ldexp.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto ldexp(T v, int e2) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto ldexp(T v, int e2) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/legendre.hpp
+++ b/include/boost/decimal/detail/cmath/legendre.hpp
@@ -21,7 +21,9 @@ namespace decimal {
 
 namespace detail {
 
-template <typename T1, typename T2, typename T3>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T3>
 constexpr auto legendre_next(unsigned l, T1 x, T2 Pl, T3 Plm1) noexcept
 {
     using result_type = promote_args_t<T1, T2, T3>;
@@ -30,7 +32,7 @@ constexpr auto legendre_next(unsigned l, T1 x, T2 Pl, T3 Plm1) noexcept
 
 // Implement Legendre P and Q polynomials via recurrence:
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr T legendre_impl(unsigned l, T x) noexcept
+constexpr auto legendre_impl(unsigned l, T x) noexcept
 {
     if (x < -1 || x > 1 || l > 128)
     {
@@ -63,8 +65,9 @@ constexpr T legendre_impl(unsigned l, T x) noexcept
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto legendre(unsigned n, T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto legendre(unsigned n, T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return detail::legendre_impl(n, x);
 }

--- a/include/boost/decimal/detail/cmath/lgamma.hpp
+++ b/include/boost/decimal/detail/cmath/lgamma.hpp
@@ -24,8 +24,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto lgamma(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto lgamma(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/log.hpp
+++ b/include/boost/decimal/detail/cmath/log.hpp
@@ -25,7 +25,7 @@ namespace detail {
 #  pragma clang diagnostic ignored "-Wmissing-braces"
 #endif
 
-template <typename T>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
 static constexpr std::array<T, 11> small_coefficient_table {
     // (1,) 12, 80, 448, 2304, 11264, 53248, 245760, 1114112, 4980736, 22020096, 96468992, ...
     // See also Sloane's A058962 at: https://oeis.org/A058962
@@ -52,7 +52,7 @@ static constexpr std::array<T, 11> small_coefficient_table {
     T { UINT64_C(103660251783288043), -18 - 7 }  // * z^23
 };
 
-template <typename T>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
 static constexpr std::array<T, 11> large_coefficient_table {
     T{uint128{UINT64_C(451750905202293), UINT64_C(9484758194528277842)}, -35},  // z^3
     T{uint128{UINT64_C(67762635780344), UINT64_C(500376525493764096)}, -35},    // z^5
@@ -73,8 +73,9 @@ static constexpr std::array<T, 11> large_coefficient_table {
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto log(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto log(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero { 0, 0 };
     constexpr T one  { 1, 0 };

--- a/include/boost/decimal/detail/cmath/log10.hpp
+++ b/include/boost/decimal/detail/cmath/log10.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto log10(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto log10(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     // TODO(ckormanyos) Actually this is eintirely preliminary. The implementation
     // of log10 will/should-be entirely re-worked with specific base-10-relevant details.

--- a/include/boost/decimal/detail/cmath/log1p.hpp
+++ b/include/boost/decimal/detail/cmath/log1p.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto log1p(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto log1p(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/log2.hpp
+++ b/include/boost/decimal/detail/cmath/log2.hpp
@@ -18,8 +18,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto log2(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto log2(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return log(x) / numbers::ln2_v<T>;
 }

--- a/include/boost/decimal/detail/cmath/logb.hpp
+++ b/include/boost/decimal/detail/cmath/logb.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto logb(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto logb(T num) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc {fpclassify(num)};
 

--- a/include/boost/decimal/detail/cmath/modf.hpp
+++ b/include/boost/decimal/detail/cmath/modf.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto modf(T x, T* iptr) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto modf(T x, T* iptr) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
     const auto is_neg {x < zero};

--- a/include/boost/decimal/detail/cmath/nan.hpp
+++ b/include/boost/decimal/detail/cmath/nan.hpp
@@ -34,10 +34,11 @@ constexpr auto nand32(const char* arg) noexcept -> decimal32
     return detail::nan_impl<decimal32>(arg);
 }
 
-template <typename Dec>
-constexpr auto nan(const char* arg) noexcept -> Dec
+template <typename T>
+constexpr auto nan(const char* arg) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
-    return detail::nan_impl<Dec>(arg);
+    return detail::nan_impl<T>(arg);
 }
 
 constexpr auto nand64(const char* arg) noexcept -> decimal64

--- a/include/boost/decimal/detail/cmath/nearbyint.hpp
+++ b/include/boost/decimal/detail/cmath/nearbyint.hpp
@@ -14,8 +14,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto nearbyint(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto nearbyint(T num) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return rint(num);
 }

--- a/include/boost/decimal/detail/cmath/next.hpp
+++ b/include/boost/decimal/detail/cmath/next.hpp
@@ -23,10 +23,10 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1, BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T1,
+          BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T2>
 constexpr auto nextafter(T1 val, T2 direction) noexcept
-    -> std::enable_if_t<(detail::is_decimal_floating_point_v<T1> || detail::is_decimal_floating_point_v<T2>),
-                         detail::promote_args_t<T1, T2>>
+    BOOST_DECIMAL_REQUIRES_TWO(detail::is_decimal_floating_point_v, T1, detail::is_decimal_floating_point_v, T2)
 {
     if (isnan(val) || isinf(val))
     {
@@ -44,9 +44,9 @@ constexpr auto nextafter(T1 val, T2 direction) noexcept
     return val - std::numeric_limits<T1>::epsilon();
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+template <typename T>
 BOOST_DECIMAL_CXX20_CONSTEXPR auto nexttoward(T val, long double direction) noexcept
-    -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto dec_direction {static_cast<T>(direction)};
     return nextafter(val, dec_direction);

--- a/include/boost/decimal/detail/cmath/remainder.hpp
+++ b/include/boost/decimal/detail/cmath/remainder.hpp
@@ -15,8 +15,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto remainder(T x, T y) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto remainder(T x, T y) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
     constexpr T half {5, -1};

--- a/include/boost/decimal/detail/cmath/remquo.hpp
+++ b/include/boost/decimal/detail/cmath/remquo.hpp
@@ -16,8 +16,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto remquo(T x, T y, int* quo) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto remquo(T x, T y, int* quo) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     using unsigned_significand_type = std::conditional_t<std::is_same<T, decimal128>::value, detail::uint128, std::uint64_t>;
 

--- a/include/boost/decimal/detail/cmath/rint.hpp
+++ b/include/boost/decimal/detail/cmath/rint.hpp
@@ -42,7 +42,7 @@ constexpr auto rint_impl(T1& sig, T2 exp, bool sign)
 #endif
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T, BOOST_DECIMAL_INTEGRAL Int>
-constexpr auto lrint_impl(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, Int>
+constexpr auto lrint_impl(T num) noexcept -> Int
 {
     constexpr T zero {0, 0};
     constexpr T lmax {(std::numeric_limits<Int>::max)()};
@@ -98,8 +98,9 @@ constexpr auto lrint_impl(T num) noexcept -> std::enable_if_t<detail::is_decimal
 } //namespace detail
 
 // Rounds the number using the default rounding mode
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto rint(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto rint(T num) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
     constexpr T max_round_value {1 / std::numeric_limits<T>::epsilon()};
@@ -127,14 +128,16 @@ constexpr auto rint(T num) noexcept -> std::enable_if_t<detail::is_decimal_float
     return {sig, 0, is_neg};
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto lrint(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, long>
+template <typename T>
+constexpr auto lrint(T num) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, long)
 {
     return detail::lrint_impl<T, long>(num);
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto llrint(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, long long>
+template <typename T>
+constexpr auto llrint(T num) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, long long)
 {
     return detail::lrint_impl<T, long long>(num);
 }

--- a/include/boost/decimal/detail/cmath/round.hpp
+++ b/include/boost/decimal/detail/cmath/round.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto round(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto round(T num) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
     constexpr T half {5, -1};
@@ -53,7 +54,7 @@ namespace detail {
 #endif
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T, BOOST_DECIMAL_INTEGRAL Int>
-constexpr auto int_round_impl(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, Int>
+constexpr auto int_round_impl(T num) noexcept -> Int
 {
     constexpr T zero {0, 0};
     constexpr T lmax {(std::numeric_limits<Int>::max)()};
@@ -88,14 +89,16 @@ constexpr auto int_round_impl(T num) noexcept -> std::enable_if_t<detail::is_dec
 
 } //namespace detail
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto lround(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, long>
+template <typename T>
+constexpr auto lround(T num) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, long)
 {
     return detail::int_round_impl<T, long>(num);
 }
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto llround(T num) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, long long>
+template <typename T>
+constexpr auto llround(T num) noexcept
+    BOOST_DECIMAL_REQUIRES_RETURN(detail::is_decimal_floating_point_v, T, long long)
 {
     return detail::int_round_impl<T, long long>(num);
 }

--- a/include/boost/decimal/detail/cmath/sin.hpp
+++ b/include/boost/decimal/detail/cmath/sin.hpp
@@ -20,8 +20,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto sin(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto sin(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/sinh.hpp
+++ b/include/boost/decimal/detail/cmath/sinh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto sinh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto sinh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/sqrt.hpp
+++ b/include/boost/decimal/detail/cmath/sqrt.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto sqrt(T val) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto sqrt(T val) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr T zero {0, 0};
 

--- a/include/boost/decimal/detail/cmath/tan.hpp
+++ b/include/boost/decimal/detail/cmath/tan.hpp
@@ -20,8 +20,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto tan(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto tan(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/tanh.hpp
+++ b/include/boost/decimal/detail/cmath/tanh.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto tanh(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto tanh(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     const auto fpc = fpclassify(x);
 

--- a/include/boost/decimal/detail/cmath/tgamma.hpp
+++ b/include/boost/decimal/detail/cmath/tgamma.hpp
@@ -17,8 +17,9 @@
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto tgamma(T x) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T> // NOLINT(misc-no-recursion)
+template <typename T>
+constexpr auto tgamma(T x) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     T result { };
 

--- a/include/boost/decimal/detail/cmath/trunc.hpp
+++ b/include/boost/decimal/detail/cmath/trunc.hpp
@@ -11,13 +11,13 @@
 #include <boost/decimal/detail/cmath/floor.hpp>
 #include <boost/decimal/detail/cmath/ceil.hpp>
 #include <type_traits>
-#include <cmath>
 
 namespace boost {
 namespace decimal {
 
-template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
-constexpr auto trunc(T val) noexcept -> std::enable_if_t<detail::is_decimal_floating_point_v<T>, T>
+template <typename T>
+constexpr auto trunc(T val) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return (val > 0) ? floor(val) : ceil(val);
 }

--- a/include/boost/decimal/detail/concepts.hpp
+++ b/include/boost/decimal/detail/concepts.hpp
@@ -9,7 +9,33 @@
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/type_traits.hpp>
 
-#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && !defined(BOOST_MATH_DISABLE_CONCEPTS)
+// GCC-11 yields internal compiler errors when using the concepts
+
+/*
+./boost/decimal/detail/concepts.hpp:239:80: note: in definition of macro 'BOOST_DECIMAL_REQUIRES_RETURN'
+  239 | #define BOOST_DECIMAL_REQUIRES_RETURN(X, T, ReturnType) -> ReturnType requires X<T>
+      |                                                                                ^
+0xe3223b internal_error(char const*, ...)
+    ???:0
+0xf56ed4 duplicate_decls(tree_node*, tree_node*, bool, bool)
+    ???:0
+0xf60a2b pushdecl_namespace_level(tree_node*, bool)
+    ???:0
+0x10801ca push_template_decl(tree_node*, bool)
+    ???:0
+0x1527ec1 do_friend(tree_node*, tree_node*, tree_node*, tree_node*, overload_flags, bool)
+    ???:0
+0xfc4e1e grokdeclarator(cp_declarator const*, cp_decl_specifier_seq*, decl_context, int, tree_node**)
+    ???:0
+0x100dcf4 grokfield(cp_declarator const*, cp_decl_specifier_seq*, tree_node*, bool, tree_node*, tree_node*)
+    ???:0
+0x149dce3 c_parse_file()
+    ???:0
+0x148d4de c_common_parse_file()
+    ???:0
+*/
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && !defined(BOOST_MATH_DISABLE_CONCEPTS) &&\
+    (!defined(__GNUC__) || __GNUC__ != 11)
 
 #if __has_include(<concepts>)
 

--- a/include/boost/decimal/detail/concepts.hpp
+++ b/include/boost/decimal/detail/concepts.hpp
@@ -1,9 +1,13 @@
-// Copyright 2022 - 2023 Matt Borland
+// Copyright 2022 - 2024 Matt Borland
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
 #ifndef BOOST_DECIMAL_DETAIL_CONCEPTS
 #define BOOST_DECIMAL_DETAIL_CONCEPTS
+
+#include <type_traits>
+#include <boost/decimal/detail/promotion.hpp>
+#include <boost/decimal/detail/type_traits.hpp>
 
 #if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && !defined(BOOST_MATH_DISABLE_CONCEPTS)
 
@@ -13,11 +17,9 @@
 #include <algorithm>
 #include <concepts>
 #include <functional>
-#include <type_traits>
 #include <limits>
 #include <iterator>
 #include <complex>
-#include <boost/decimal/detail/type_traits.hpp>
 
 namespace boost::decimal::concepts {
 
@@ -232,7 +234,9 @@ concept decimal_floating_point_type = boost::decimal::detail::is_decimal_floatin
 #define BOOST_DECIMAL_OUTPUT_ITER(I, T) boost::decimal::concepts::output_iterator<I, T>
 #define BOOST_DECIMAL_REQUIRES_ITER(X) requires X
 
-#define BOOST_DECIMAL_REQUIRES(X, T) requires X<T>
+#define BOOST_DECIMAL_REQUIRES(X, T) -> T requires X<T>
+#define BOOST_DECIMAL_REQUIRES_TWO(X1, T1, X2, T2) -> detail::promote_args_t<T1, T2> requires X1<T1> && X2<T2>
+#define BOOST_DECIMAL_REQUIRES_RETURN(X, T, ReturnType) -> ReturnType requires X<T>
 
 #ifdef BOOST_DECIMAL_EXEC_COMPATIBLE
 #include <execution>
@@ -374,7 +378,15 @@ concept execution_policy = std::is_execution_policy_v<std::remove_cvref_t<T>>;
 #endif
 
 #ifndef BOOST_DECIMAL_REQUIRES
-#  define BOOST_DECIMAL_REQUIRES(X, T)
+#  define BOOST_DECIMAL_REQUIRES(X, T) -> std::enable_if_t<X<T>, T>
+#endif
+
+#ifndef BOOST_DECIMAL_REQUIRES_TWO
+#  define BOOST_DECIMAL_REQUIRES_TWO(X1, T1, X2, T2) -> std::enable_if_t<X1<T1> && X2<T2>, detail::promote_args_t<T1, T2>>
+#endif
+
+#ifndef BOOST_DECIMAL_REQUIRES_RETURN
+#  define BOOST_DECIMAL_REQUIRES_RETURN(X, T, ReturnType) -> std::enable_if_t<X<T>, ReturnType>
 #endif
 
 #endif //BOOST_DECIMAL_DETAIL_CONCEPTS


### PR DESCRIPTION
Removes SFINAE expressions when concepts are available to improve error messages.
See: #473 