### PR TITLE
Improve root guesses

### DIFF
--- a/include/boost/decimal/detail/cmath/cbrt.hpp
+++ b/include/boost/decimal/detail/cmath/cbrt.hpp
@@ -54,9 +54,21 @@ constexpr auto cbrt_impl(T val) noexcept
     else
     {
         constexpr T epsilon = std::numeric_limits<T>::epsilon() * 100;
-        T error = 1 / epsilon;
+        T error = one / epsilon;
 
-        T x = val > 1 ? val / 3 : val * 2; // Initial Guess
+        T x {};
+        if (val > one)
+        {
+            // Scale down if val is large by dividing the exp by 3
+            int exp {};
+            auto sig = frexp10(val, &exp);
+            x = T{sig, exp / 3};
+        }
+        else
+        {
+            // Trivial heuristic
+            x = val * 2;
+        }
 
         while (error > epsilon)
         {

--- a/include/boost/decimal/detail/cmath/sqrt.hpp
+++ b/include/boost/decimal/detail/cmath/sqrt.hpp
@@ -48,7 +48,8 @@ constexpr auto sqrt_impl(T val) noexcept
     }
     else
     {
-        constexpr T epsilon = std::numeric_limits<T>::epsilon() * 100;
+        // Loosens tolerance with the increase in digits so it's not excessively expensive
+        constexpr T epsilon = std::numeric_limits<T>::epsilon() * std::numeric_limits<T>::digits10;
         constexpr T one { 1, 0 };
         constexpr T half {5, -1};
         T error = one / epsilon;

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -600,8 +600,8 @@ void test_two_val_hypot()
         }
     }
 
-    const auto big_val {dist(rng)};
-    BOOST_TEST_EQ(hypot(Dec(big_val), Dec(big_val * 1e20F)), Dec(big_val * 1e20F));
+    const auto big_val {static_cast<double>(dist(rng))};
+    BOOST_TEST_EQ(hypot(Dec(big_val), Dec(big_val * 1e100)), Dec(big_val * 1e100));
 
     Dec inf {std::numeric_limits<Dec>::infinity() * static_cast<int>(dist(rng))};
     Dec nan {std::numeric_limits<Dec>::quiet_NaN() * static_cast<int>(dist(rng))};


### PR DESCRIPTION
Closes: #442 
Closes: #251 

For cbrt reduced average iterations from 11.6 to 9.4 with decimal32 with numbers in the testing range (1, 1e3). (0,1) is not changed.