### PR TITLE
Add drone debugging variable DRONE_STAGE_MACHINE

### DIFF
--- a/.drone/drone.bat
+++ b/.drone/drone.bat
@@ -7,6 +7,8 @@
 set LIBRARY=%1
 set DRONE_BUILD_DIR=%CD%
 
+echo $env:DRONE_STAGE_MACHINE
+
 set BOOST_BRANCH=develop
 if "%DRONE_BRANCH%" == "master" set BOOST_BRANCH=master
 cd ..

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -6,6 +6,8 @@
 
 set -ex
 export PATH=~/.local/bin:/usr/local/bin:$PATH
+uname -a
+echo $DRONE_STAGE_MACHINE
 
 DRONE_BUILD_DIR=$(pwd)
 


### PR DESCRIPTION
Since the jsonnet method doesn't call functions.star, please add this DRONE_STAGE_MACHINE variable to any projects, as shown.

The recent test is inconclusive, because the agent machine was not known.  An ephemeral server in the cloud is showing "1/2 status checks passed" as if there are hardware problems.

How about splitting the gcc 7 job into two separate parts: 32, and 64 bit.