### PR TITLE
Make float conversions explicit again

### DIFF
--- a/doc/decimal/config.adoc
+++ b/doc/decimal/config.adoc
@@ -15,3 +15,13 @@ The following configuration macros are available:
 - `BOOST_DECIMAL_DISABLE_IOSTREAM`: Disables the use of I/O streaming and removes all associated headers (e.g. `<iostream>`, `<iosfwd>`, `<cwchar>`, etc.)
 
 - `BOOST_DECIMAL_DISABLE_CLIB`: Defines both of the above macros. In testing this reduces ROM usage by ~50%.
+
+- `BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS`: Allows a binary floating-point type (e.g. `double`) to be implicitly converted to a decimal floating point type.
+This option is not recommended, but can be useful if you want to use specific functionality from the standard library with internal conversions such as:
+
+[source, c++]
+----
+constexpr decimal64 half {5, -1};
+std::complex<decimal64> test_val {half, half};
+const auto res = std::acos(test_val);
+----

--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -240,6 +240,9 @@ public:
     #else
     template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, bool> = true>
     #endif
+    #ifndef BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS
+    explicit
+    #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal128(Float val) noexcept;
 
     template <typename Float>

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -223,6 +223,9 @@ public:
     #else
     template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, bool> = true>
     #endif
+    #ifndef BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS
+    explicit
+    #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal32(Float val) noexcept;
 
     template <typename Float>

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -233,6 +233,9 @@ public:
     #else
     template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, bool> = true>
     #endif
+    #ifndef BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS
+    explicit
+    #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal64(Float val) noexcept;
 
     template <typename Float>

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -87,6 +87,7 @@ run test_ellint_1.cpp ;
 run test_emulated128.cpp ;
 run test_erf.cpp ;
 run test_exp.cpp ;
+compile-fail test_explicit_floats.cpp ;
 run test_expm1.cpp ;
 run test_fenv.cpp ;
 run test_float_conversion.cpp ;

--- a/test/github_issue_426.cpp
+++ b/test/github_issue_426.cpp
@@ -2,6 +2,8 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#define BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS
+
 #include <boost/decimal.hpp>
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/test_assoc_legendre.cpp
+++ b/test/test_assoc_legendre.cpp
@@ -74,10 +74,10 @@ void test()
         }
     }
 
-    BOOST_TEST(isnan(assoc_legendre(1U, 1U, dist(rng) * std::numeric_limits<Dec>::signaling_NaN())));
+    BOOST_TEST(isnan(assoc_legendre(1U, 1U, Dec{dist(rng)} * std::numeric_limits<Dec>::signaling_NaN())));
     BOOST_TEST(isnan(assoc_legendre(1U, 1U, Dec{10})));
     BOOST_TEST(isnan(assoc_legendre(1U, 1U, Dec{-10})));
-    BOOST_TEST(isnan(assoc_legendre(200U, 1U, dist(rng) * Dec{1})));
+    BOOST_TEST(isnan(assoc_legendre(200U, 1U, Dec{dist(rng)} * Dec{1})));
 }
 
 // LCOV_EXCL_START

--- a/test/test_boost_math_univariate_stats.cpp
+++ b/test/test_boost_math_univariate_stats.cpp
@@ -60,10 +60,10 @@ std::vector<T> generate_random_vector(std::size_t size, unsigned seed)
 
     std::mt19937 gen(seed);
 
-    boost::random::normal_distribution<T> dis(0, 1);
+    boost::random::normal_distribution<double> dis(0, 1);
     for(std::size_t i = 0; i < v.size(); ++i)
     {
-        v[i] = dis(gen);
+        v[i] = T{dis(gen)};
     }
     return v;
 }

--- a/test/test_explicit_floats.cpp
+++ b/test/test_explicit_floats.cpp
@@ -1,0 +1,29 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+
+using namespace boost::decimal;
+
+template <typename T>
+void test()
+{
+    constexpr T half {5, -1};
+
+    const auto temp1 = half + 1.0;
+    static_cast<void>(temp1);
+    const auto temp2 = half > 1.0;
+    static_cast<void>(temp2);
+    const auto temp3 = half / 1.0;
+    static_cast<void>(temp3);
+}
+
+int main()
+{
+    test<decimal32>();
+    test<decimal64>();
+    test<decimal128>();
+
+    return 0;
+}

--- a/test/test_legendre.cpp
+++ b/test/test_legendre.cpp
@@ -69,10 +69,10 @@ void test()
         }
     }
 
-    BOOST_TEST(isnan(legendre(1U, dist(rng) * std::numeric_limits<Dec>::signaling_NaN())));
+    BOOST_TEST(isnan(legendre(1U, Dec{dist(rng)} * std::numeric_limits<Dec>::signaling_NaN())));
     BOOST_TEST(isnan(legendre(1U, Dec{10})));
     BOOST_TEST(isnan(legendre(1U, Dec{-10})));
-    BOOST_TEST(isnan(legendre(200U, dist(rng) * Dec{1})));
+    BOOST_TEST(isnan(legendre(200U, Dec{dist(rng)} * Dec{1})));
 }
 
 int main()


### PR DESCRIPTION
Adds configuration macro `BOOST_DECIMAL_ALLOW_IMPLICIT_CONVERSIONS` if the user wants it.