### PR TITLE
Improve operations expanding or shrinking significand

### DIFF
--- a/doc/decimal/benchmarks.adoc
+++ b/doc/decimal/benchmarks.adoc
@@ -22,7 +22,7 @@ An example on Linux with b2: `../../../b2 cxxstd=20 toolset=gcc-13 define=BOOST_
 
 == Comparisons
 
-The benchmark for comparisons generates a random vector containing 2,000,000 elements and does operations `>`, `>=`, `<`, `<=`, `==`, and `!=` between `vec[i] and vec[i + 1]`.
+The benchmark for comparisons generates a random vector containing 2,000,000 elements and does operations `>`, `>=`, `<`, `\<=`, `==`, and `!=` between `vec[i] and vec[i + 1]`.
 This is repeated 5 times to generate stable results.
 
 === M1 macOS Results

--- a/doc/decimal/benchmarks.adoc
+++ b/doc/decimal/benchmarks.adoc
@@ -32,20 +32,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 9032
-| 1.589
+| 8764
+| 1.577
 | `double`
-| 5684
+| 5559
 | 1.000
 | `decimal32`
-| 285,453
-| 50.2204
+| 276,124
+| 49.672
 | `decimal64`
-| 352,644
-| 62.042
+| 355,999
+| 64.760
 | `decimal128`
-| 15,355,817
-| 2701.590
+| 989,028
+| 177.915
 |===
 
 == Basic Operations
@@ -62,20 +62,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 1641
-| 0.965
+| 2113
+| 0.739
 | `double`
-| 1708
+| 2860
 | 1.000
 | `decimal32`
-| 378,252
-| 221.459
+| 353,836
+| 123.719
 | `decimal64`
-| 589,313
-| 345.031
+| 409,098
+| 143.041
 | `decimal128`
-| 13,829,995
-| 8097.190
+| 2,418,039
+| 845.468
 |===
 
 ==== Subtraction
@@ -83,20 +83,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 3633
-| 2.221
+| 1782
+| 1.061
 | `double`
-| 1636
+| 1680
 | 1.000
 | `decimal32`
-| 307,765
-| 188.120
+| 293,927
+| 174.957
 | `decimal64`
-| 461,442
-| 282.055
+| 329,425
+| 196.086
 | `decimal128`
-| 11,449,306
-| 6998.350
+| 1,527,261
+| 909.084
 |===
 
 ==== Multiplication
@@ -104,20 +104,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 1678
-| 0.523
+| 1691
+| 0.979
 | `double`
-| 3209
+| 1728
 | 1.000
 | `decimal32`
-| 310,543
-| 96.773
+| 309,117
+| 178.887
 | `decimal64`
-| 570,938
-| 177.918
+| 408,010
+| 236.117
 | `decimal128`
-| 9,434,297
-| 2939.95
+| 2,506,105
+| 1450.292
 |===
 
 ==== Division
@@ -125,20 +125,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 2019
-| 0.565
+| 2058
+| 0.846
 | `double`
-| 3572
+| 2434
 | 1.000
 | `decimal32`
-| 322,116
-| 90.178
+| 304,852
+| 125.247
 | `decimal64`
-| 734,173
-| 205.536
+| 519,990
+| 213.636
 | `decimal128`
-| 14,592,284
-| 4085.19
+| 3,534,909
+| 1452.304
 |===
 
 == Selected Special Functions
@@ -155,20 +155,20 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 1904
-| 0.565
+| 2021
+| 0.626
 | `double`
-| 3746
+| 3229
 | 1.000
 | `decimal32`
-| 5,050,241
-| 1341.72
+| 4,826,066
+| 1494.601
 | `decimal64`
-| 12,084,821
-| 3210.630
+| 7,780,637
+| 2409.612
 | `decimal128`
-| 275,779,340
-| 73267.60
+| 100,269,145
+| 31052.693
 |===
 
 == `<charconv>`

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -19,6 +19,7 @@
 #include <boost/decimal/detail/cmath/frexp10.hpp>
 #include <boost/decimal/detail/attributes.hpp>
 #include <boost/decimal/detail/countl.hpp>
+#include <boost/decimal/detail/remove_trailing_zeros.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 #include <cstdint>
@@ -412,12 +413,11 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_fixed_impl(char* first, char* last, const 
         // In general formatting we remove trailing 0s
         if (fmt == chars_format::general)
         {
-            while (significand % 10 == 0)
-            {
-                significand /= 10;
-                ++exponent;
-                --num_dig;
-            }
+
+            const auto zeros_removal {remove_trailing_zeros(significand)};
+            significand = zeros_removal.trimmed_number;
+            exponent += static_cast<int>(zeros_removal.number_of_removed_zeros);
+            num_dig -= static_cast<int>(zeros_removal.number_of_removed_zeros);
         }
     }
 

--- a/include/boost/decimal/detail/normalize.hpp
+++ b/include/boost/decimal/detail/normalize.hpp
@@ -9,14 +9,14 @@
 #include <boost/decimal/detail/integer_search_trees.hpp>
 #include <boost/decimal/detail/fenv_rounding.hpp>
 #include <boost/decimal/detail/attributes.hpp>
+#include <boost/decimal/detail/remove_trailing_zeros.hpp>
 
 namespace boost {
 namespace decimal {
 namespace detail {
 
 // Converts the significand to full precision to remove the effects of cohorts
-template <typename TargetDecimalType = decimal32, typename T1, typename T2,
-          std::enable_if_t<!std::is_same<TargetDecimalType, decimal128>::value, bool> = true>
+template <typename TargetDecimalType = decimal32, typename T1, typename T2>
 constexpr auto normalize(T1& significand, T2& exp) noexcept -> void
 {
     auto digits {num_digits(significand)};
@@ -36,43 +36,6 @@ constexpr auto normalize(T1& significand, T2& exp) noexcept -> void
             #if ((defined(__GNUC__) && (__GNUC__ > 12)) && !defined(__clang__))
             #  pragma GCC diagnostic push
             #  pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
-            #endif
-
-            ++exp;
-
-            #if ((defined(__GNUC__) && (__GNUC__ > 12)) && !defined(__clang__))
-            #  pragma GCC diagnostic pop
-            #endif
-
-            --digits;
-        }
-
-        exp += detail::fenv_round<TargetDecimalType>(significand, significand < 0);
-    }
-}
-
-template <typename TargetDecimalType = decimal32, typename T1, typename T2,
-          std::enable_if_t<std::is_same<TargetDecimalType, decimal128>::value, bool> = true>
-constexpr auto normalize(T1& significand, T2& exp) noexcept
-{
-    auto digits {num_digits(significand)};
-
-    if (digits < detail::precision_v<decimal128>)
-    {
-        const auto zeros_needed {detail::precision_v<TargetDecimalType> - digits};
-        significand *= pow10(static_cast<T1>(zeros_needed));
-        exp -= zeros_needed;
-    }
-
-    else if (digits > detail::precision_v<TargetDecimalType>)
-    {
-        while (digits > detail::precision_v<TargetDecimalType> + 1)
-        {
-            significand /= 10;
-
-            #if ((defined(__GNUC__) && (__GNUC__ > 12)) && !defined(__clang__))
-            #  pragma GCC diagnostic push
-                #  pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
             #endif
 
             ++exp;

--- a/include/boost/decimal/detail/normalize.hpp
+++ b/include/boost/decimal/detail/normalize.hpp
@@ -23,12 +23,9 @@ constexpr auto normalize(T1& significand, T2& exp) noexcept -> void
 
     if (digits < detail::precision_v<TargetDecimalType>)
     {
-        while (digits < detail::precision_v<TargetDecimalType>)
-        {
-            significand *= 10;
-            --exp;
-            ++digits;
-        }
+        const auto zeros_needed {detail::precision_v<TargetDecimalType> - digits};
+        significand *= pow10(static_cast<T1>(zeros_needed));
+        exp -= zeros_needed;
     }
     else if (digits > detail::precision_v<TargetDecimalType>)
     {
@@ -62,12 +59,9 @@ constexpr auto normalize(T1& significand, T2& exp) noexcept
 
     if (digits < detail::precision_v<decimal128>)
     {
-        while (digits < detail::precision_v<decimal128>)
-        {
-            significand *= UINT64_C(10);
-            --exp;
-            ++digits;
-        }
+        const auto zeros_needed {detail::precision_v<TargetDecimalType> - digits};
+        significand *= pow10(static_cast<T1>(zeros_needed));
+        exp -= zeros_needed;
     }
 
     else if (digits > detail::precision_v<TargetDecimalType>)

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -1,0 +1,73 @@
+// Copyright 2024 Junekey Jeon
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// See: https://github.com/jk-jeon/rtz_benchmark/tree/master
+
+#ifndef BOOST_DECIMAL_DETAIL_REMOVE_TRAILING_ZEROS_HPP
+#define BOOST_DECIMAL_DETAIL_REMOVE_TRAILING_ZEROS_HPP
+
+#include <boost/decimal/detail/type_traits.hpp>
+#include <boost/decimal/detail/concepts.hpp>
+
+#ifndef BOOST_DECIMAL_BUILD_MODULE
+#include <cstdint>
+#endif
+
+namespace boost {
+namespace decimal {
+namespace detail {
+
+// n is assumed to be at most of bit_width bits.
+template <std::size_t bit_width, typename UInt>
+constexpr auto rotr(UInt n, unsigned int r) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_unsigned_v, UInt)
+{
+    r &= (bit_width - 1);
+    return (n >> r) | (n << ((bit_width - r) & (bit_width - 1)));
+}
+
+constexpr auto remove_trailing_zeros(std::uint32_t n) noexcept -> std::uint32_t
+{
+    auto r = rotr<32>(n * UINT32_C(184254097), 4);
+    auto b = r < UINT32_C(429497);
+    n = b ? r : n;
+
+    r = rotr<32>(n * UINT32_C(42949673), 2);
+    b = r < UINT32_C(42949673);
+    n = b ? r : n;
+
+    r = rotr<32>(n * UINT32_C(1288490189), 1);
+    b = r < UINT32_C(429496730);
+    n = b ? r : n;
+
+    return n;
+}
+
+constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> std::uint64_t
+{
+    auto r = rotr<64>(n * UINT64_C(28999941890838049), 8);
+    auto b = r < UINT64_C(184467440738);
+    n = b ? r : n;
+
+    r = rotr<64>(n * UINT64_C(182622766329724561), 4);
+    b = r < UINT64_C(1844674407370956);
+    n = b ? r : n;
+
+    r = rotr<64>(n * UINT64_C(10330176681277348905), 2);
+    b = r < UINT64_C(184467440737095517);
+    n = b ? r : n;
+
+    r = rotr<64>(n * UINT32_C(14757395258967641293), 1);
+    b = r < UINT64_C(1844674407370955162);
+    n = b ? r : n;
+
+    return n;
+}
+
+} // namespace detail
+} // namespace decimal
+} // namespace boost
+
+#endif //BOOST_DECIMAL_DETAIL_REMOVE_TRAILING_ZEROS_HPP

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/decimal/detail/type_traits.hpp>
 #include <boost/decimal/detail/concepts.hpp>
+#include <boost/decimal/detail/emulated128.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 #include <cstdint>
@@ -28,42 +29,74 @@ constexpr auto rotr(UInt n, unsigned int r) noexcept
     return (n >> r) | (n << ((bit_width - r) & (bit_width - 1)));
 }
 
-constexpr auto remove_trailing_zeros(std::uint32_t n) noexcept -> std::uint32_t
+template <typename T>
+struct remove_trailing_zeros_return
 {
+    T trimmed_number;
+    std::size_t number_of_removed_zeros;
+};
+
+constexpr auto remove_trailing_zeros(std::uint32_t n) noexcept -> remove_trailing_zeros_return<std::uint32_t>
+{
+    std::size_t s {};
+
     auto r = rotr<32>(n * UINT32_C(184254097), 4);
     auto b = r < UINT32_C(429497);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
     r = rotr<32>(n * UINT32_C(42949673), 2);
     b = r < UINT32_C(42949673);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
     r = rotr<32>(n * UINT32_C(1288490189), 1);
     b = r < UINT32_C(429496730);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    return n;
+    return {n, s};
 }
 
-constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> std::uint64_t
+constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailing_zeros_return<std::uint64_t>
 {
+    std::size_t s {};
+
     auto r = rotr<64>(n * UINT64_C(28999941890838049), 8);
     auto b = r < UINT64_C(184467440738);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
     r = rotr<64>(n * UINT64_C(182622766329724561), 4);
     b = r < UINT64_C(1844674407370956);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
     r = rotr<64>(n * UINT64_C(10330176681277348905), 2);
     b = r < UINT64_C(184467440737095517);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
     r = rotr<64>(n * UINT32_C(14757395258967641293), 1);
     b = r < UINT64_C(1844674407370955162);
+    s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    return n;
+    return {n, s};
+}
+
+// TODO(mborland): Make this better. Check lower word for equal to 0.
+constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
+{
+    std::size_t s {};
+
+    while (n % 10 == 0)
+    {
+        n /= 10;
+        ++s;
+    }
+
+    return {n, s};
 }
 
 } // namespace detail

--- a/include/boost/decimal/detail/type_traits.hpp
+++ b/include/boost/decimal/detail/type_traits.hpp
@@ -44,6 +44,9 @@ template <typename T>
 constexpr bool is_signed_v = is_signed<T>::value;
 
 template <typename T>
+constexpr bool is_unsigned_v = !is_signed_v<T>;
+
+template <typename T>
 struct make_unsigned { using type = std::make_unsigned_t<T>; };
 
 template <>

--- a/test/test_snprintf.cpp
+++ b/test/test_snprintf.cpp
@@ -77,6 +77,7 @@ void test_uppercase(T value, const char* format_sprintf, chars_format fmt = char
     BOOST_TEST_EQ(num_bytes, r.ptr - charconv_buffer);
 }
 
+#if !(defined(__APPLE__) && defined(__GNUC__) && !defined(__clang__))
 void test_locales()
 {
     const char buffer[] = "1,1897e+02";
@@ -89,7 +90,7 @@ void test_locales()
         std::locale::global(std::locale("de_DE.UTF-8"));
         #endif
     }
-        // LCOV_EXCL_START
+    // LCOV_EXCL_START
     catch (...)
     {
         std::cerr << "Locale not installed. Skipping test." << std::endl;
@@ -101,6 +102,7 @@ void test_locales()
     snprintf(printf_buffer, sizeof(printf_buffer), "%.4De", decimal64{11897, -2});
     BOOST_TEST_CSTR_EQ(printf_buffer, buffer);
 }
+#endif
 
 template <typename T>
 void test_bootstrap()
@@ -174,7 +176,10 @@ int main()
     test_bootstrap<decimal64>();
     test_bootstrap<decimal128>();
 
+    // Homebrew gcc on mac does not support locales
+    #if !(defined(__APPLE__) && defined(__GNUC__) && !defined(__clang__))
     test_locales();
+    #endif
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Closes: #515 
Closes: #516 

For add and sub Decimal64 is ~2x faster, and Decimal128 is ~10x faster.