### PR TITLE
Faster zero removal

### DIFF
--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -95,14 +95,17 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
     return {n, s};
 }
 
-namespace impl {
-
-constexpr auto remove_trailing_zeros_impl(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
+constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
 {
     std::size_t s {};
 
-    auto r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
-    auto b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
+    auto r = rotr<128>(n * uint128(UINT64_C(0x62B42691AD836EB1), UINT64_C(0x16590F420A835081)), 32);
+    auto b = r < uint128 {UINT64_C(0x0), UINT64_C(0x33EC48)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
+    b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
@@ -127,21 +130,6 @@ constexpr auto remove_trailing_zeros_impl(uint128 n) noexcept -> remove_trailing
     n = b ? r : n;
 
     return {n, s};
-}
-
-} // namespace impl
-
-constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
-{
-    const auto temp {impl::remove_trailing_zeros_impl(n)};
-    if (BOOST_DECIMAL_LIKELY(temp.number_of_removed_zeros < 31))
-    {
-        return temp;
-    }
-
-    // Since 32 is not a valid value of t we need to keep removing zeros
-    const auto round2 {remove_trailing_zeros(static_cast<std::uint32_t>(temp.trimmed_number))};
-    return {static_cast<uint128>(round2.trimmed_number), round2.number_of_removed_zeros + 31};
 }
 
 } // namespace detail

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -95,17 +95,14 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
     return {n, s};
 }
 
-constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
+namespace impl {
+
+constexpr auto remove_trailing_zeros_impl(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
 {
     std::size_t s {};
 
     auto r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
     auto b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
-    s = s * 2U + static_cast<std::size_t>(b);
-    n = b ? r : n;
-
-    r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
-    b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
@@ -130,6 +127,21 @@ constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zero
     n = b ? r : n;
 
     return {n, s};
+}
+
+} // namespace impl
+
+constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
+{
+    const auto temp {impl::remove_trailing_zeros_impl(n)};
+    if (BOOST_DECIMAL_LIKELY(temp.number_of_removed_zeros < 31))
+    {
+        return temp;
+    }
+
+    // Since 32 is not a valid value of t we need to keep removing zeros
+    const auto round2 {remove_trailing_zeros(static_cast<std::uint32_t>(temp.trimmed_number))};
+    return {static_cast<uint128>(round2.trimmed_number), round2.number_of_removed_zeros + 31};
 }
 
 } // namespace detail

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -40,8 +40,13 @@ constexpr auto remove_trailing_zeros(std::uint32_t n) noexcept -> remove_trailin
 {
     std::size_t s {};
 
-    auto r = rotr<32>(n * UINT32_C(184254097), 4);
-    auto b = r < UINT32_C(429497);
+    auto r = rotr<32>(n * UINT32_C(15273505), 8);
+    auto b = r < UINT32_C(43);
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<32>(n * UINT32_C(184254097), 4);
+    b = r < UINT32_C(429497);
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
@@ -62,8 +67,13 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
 {
     std::size_t s {};
 
-    auto r = rotr<64>(n * UINT64_C(28999941890838049), 8);
-    auto b = r < UINT64_C(184467440738);
+    auto r = rotr<64>(n * UINT64_C(230079197716545), 16);
+    auto b = r < UINT64_C(1845);
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<64>(n * UINT64_C(28999941890838049), 8);
+    b = r < UINT64_C(184467440738);
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -85,7 +85,6 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
     return {n, s};
 }
 
-// TODO(mborland): Make this better for the 2-word case
 constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
 {
     if (n.high == UINT64_C(0))
@@ -94,12 +93,23 @@ constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zero
         return {static_cast<uint128>(temp.trimmed_number), temp.number_of_removed_zeros};
     }
 
-    std::size_t s {};
+    std::size_t s = 0;
+    constexpr detail::uint128 m {UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)};
+    constexpr detail::uint128 threshold_value {UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)};
 
-    while (n % 10 == 0)
+    while (true)
     {
-        n /= 10;
-        ++s;
+        const auto r = rotr<128>(n * m, 1);
+
+        if (r < threshold_value)
+        {
+            n = r;
+            s += 1;
+        }
+        else
+        {
+            break;
+        }
     }
 
     return {n, s};

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -85,6 +85,7 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
     return {n, s};
 }
 
+/*
 constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
 {
     if (n.high == UINT64_C(0))
@@ -111,6 +112,39 @@ constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zero
             break;
         }
     }
+
+    return {n, s};
+}
+*/
+
+constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
+{
+    std::size_t s {};
+
+    auto r = rotr<128>(n * uint128{UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
+    auto b = r < uint128{UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128{UINT64_C(0x6B7213EE9F5A78), UINT64_C(0xC767074B22E90E21)}, 8);
+    b = r < uint128{UINT64_C(0x2AF31DC461), UINT64_C(0x1873BF3F70834ACE)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128{UINT64_C(0x95182A9930BE0DE), UINT64_C(0xD288CE703AFB7E91)}, 4);
+    b = r < uint128{UINT64_C(0x68DB8BAC710CB), UINT64_C(0x295E9E1B089A0276)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128{UINT64_C(0x28F5C28F5C28F5C2), UINT64_C(0x8F5C28F5C28F5C29)}, 2);
+    b = r < uint128{UINT64_C(0x28F5C28F5C28F5C), UINT64_C(0x28F5C28F5C28F5C3)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128{UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)}, 1);
+    b = r < uint128{UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
 
     return {n, s};
 }

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -95,64 +95,37 @@ constexpr auto remove_trailing_zeros(std::uint64_t n) noexcept -> remove_trailin
     return {n, s};
 }
 
-/*
-constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
-{
-    if (n.high == UINT64_C(0))
-    {
-        const auto temp {remove_trailing_zeros(n.low)};
-        return {static_cast<uint128>(temp.trimmed_number), temp.number_of_removed_zeros};
-    }
-
-    std::size_t s = 0;
-    constexpr detail::uint128 m {UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)};
-    constexpr detail::uint128 threshold_value {UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)};
-
-    while (true)
-    {
-        const auto r = rotr<128>(n * m, 1);
-
-        if (r < threshold_value)
-        {
-            n = r;
-            s += 1;
-        }
-        else
-        {
-            break;
-        }
-    }
-
-    return {n, s};
-}
-*/
-
 constexpr auto remove_trailing_zeros(uint128 n) noexcept -> remove_trailing_zeros_return<uint128>
 {
     std::size_t s {};
 
-    auto r = rotr<128>(n * uint128{UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
-    auto b = r < uint128{UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
+    auto r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
+    auto b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    r = rotr<128>(n * uint128{UINT64_C(0x6B7213EE9F5A78), UINT64_C(0xC767074B22E90E21)}, 8);
-    b = r < uint128{UINT64_C(0x2AF31DC461), UINT64_C(0x1873BF3F70834ACE)};
+    r = rotr<128>(n * uint128 {UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}, 16);
+    b = r < uint128 {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    r = rotr<128>(n * uint128{UINT64_C(0x95182A9930BE0DE), UINT64_C(0xD288CE703AFB7E91)}, 4);
-    b = r < uint128{UINT64_C(0x68DB8BAC710CB), UINT64_C(0x295E9E1B089A0276)};
+    r = rotr<128>(n * uint128 {UINT64_C(0x6B7213EE9F5A78), UINT64_C(0xC767074B22E90E21)}, 8);
+    b = r < uint128 {UINT64_C(0x2AF31DC461), UINT64_C(0x1873BF3F70834ACE)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    r = rotr<128>(n * uint128{UINT64_C(0x28F5C28F5C28F5C2), UINT64_C(0x8F5C28F5C28F5C29)}, 2);
-    b = r < uint128{UINT64_C(0x28F5C28F5C28F5C), UINT64_C(0x28F5C28F5C28F5C3)};
+    r = rotr<128>(n * uint128 {UINT64_C(0x95182A9930BE0DE), UINT64_C(0xD288CE703AFB7E91)}, 4);
+    b = r < uint128 {UINT64_C(0x68DB8BAC710CB), UINT64_C(0x295E9E1B089A0276)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 
-    r = rotr<128>(n * uint128{UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)}, 1);
-    b = r < uint128{UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)};
+    r = rotr<128>(n * uint128 {UINT64_C(0x28F5C28F5C28F5C2), UINT64_C(0x8F5C28F5C28F5C29)}, 2);
+    b = r < uint128 {UINT64_C(0x28F5C28F5C28F5C), UINT64_C(0x28F5C28F5C28F5C3)};
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * uint128 {UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)}, 1);
+    b = r < uint128 {UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)};
     s = s * 2U + static_cast<std::size_t>(b);
     n = b ? r : n;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -110,6 +110,7 @@ run test_log1p.cpp ;
 run test_pow.cpp ;
 run test_promotion.cpp ;
 run test_remainder_remquo.cpp ;
+run test_remove_trailing_zeros.cpp ;
 run test_sin_cos.cpp ;
 run test_sinh.cpp ;
 run test_snprintf.cpp ;

--- a/test/test_remove_trailing_zeros.cpp
+++ b/test/test_remove_trailing_zeros.cpp
@@ -1,0 +1,83 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <array>
+#include <limits>
+#include <cstdint>
+
+template <typename T>
+void test()
+{
+    constexpr std::array<std::uint64_t, 20> powers_of_10 =
+    {{
+             UINT64_C(1), UINT64_C(10), UINT64_C(100), UINT64_C(1000), UINT64_C(10000), UINT64_C(100000), UINT64_C(1000000),
+             UINT64_C(10000000), UINT64_C(100000000), UINT64_C(1000000000), UINT64_C(10000000000), UINT64_C(100000000000),
+             UINT64_C(1000000000000), UINT64_C(10000000000000), UINT64_C(100000000000000), UINT64_C(1000000000000000),
+             UINT64_C(10000000000000000), UINT64_C(100000000000000000), UINT64_C(1000000000000000000), UINT64_C(10000000000000000000)
+     }};
+
+    for (const auto& val : powers_of_10)
+    {
+        if (val < std::numeric_limits<T>::max())
+        {
+            const auto temp {boost::decimal::detail::remove_trailing_zeros(static_cast<T>(val))};
+            if (!BOOST_TEST_EQ(temp.trimmed_number, T(1)))
+            {
+                std::cerr << "Input Number: " << val
+                          << "\nOutput Number: " << temp.trimmed_number
+                          << "\nZeros removed: " << temp.number_of_removed_zeros << std::endl;
+            }
+        }
+    }
+}
+
+void test_extended()
+{
+    using namespace boost::decimal;
+    constexpr std::array<detail::uint128, 18> powers_of_10 =
+    {{
+        detail::uint128 {UINT64_C(0x5), UINT64_C(0x6BC75E2D63100000)},
+        detail::uint128 {UINT64_C(0x36), UINT64_C(0x35C9ADC5DEA00000)},
+        detail::uint128 {UINT64_C(0x21E), UINT64_C(0x19E0C9BAB2400000)},
+        detail::uint128 {UINT64_C(0x152D), UINT64_C(0x02C7E14AF6800000)},
+        detail::uint128 {UINT64_C(0x84595), UINT64_C(0x161401484A000000)},
+        detail::uint128 {UINT64_C(0x52B7D2), UINT64_C(0xDCC80CD2E4000000)},
+        detail::uint128 {UINT64_C(0x33B2E3C), UINT64_C(0x9FD0803CE8000000)},
+        detail::uint128 {UINT64_C(0x204FCE5E), UINT64_C(0x3E25026110000000)},
+        detail::uint128 {UINT64_C(0x1431E0FAE), UINT64_C(0x6D7217CAA0000000)},
+        detail::uint128 {UINT64_C(0xC9F2C9CD0), UINT64_C(0x4674EDEA40000000)},
+        detail::uint128 {UINT64_C(0x7E37BE2022), UINT64_C(0xC0914B2680000000)},
+        detail::uint128 {UINT64_C(0x4EE2D6D415B), UINT64_C(0x85ACEF8100000000)},
+        detail::uint128 {UINT64_C(0x314DC6448D93), UINT64_C(0x38C15B0A00000000)},
+        detail::uint128 {UINT64_C(0x1ED09BEAD87C0), UINT64_C(0x378D8E6400000000)},
+        detail::uint128 {UINT64_C(0x13426172C74D82), UINT64_C(0x2B878FE800000000)},
+        detail::uint128 {UINT64_C(0xC097CE7BC90715), UINT64_C(0xB34B9F1000000000)},
+        detail::uint128 {UINT64_C(0x785EE10D5DA46D9), UINT64_C(0x00F436A000000000)},
+        detail::uint128 {UINT64_C(0x4B3B4CA85A86C47A), UINT64_C(0x098A224000000000)}
+     }};
+
+    for (const auto& val : powers_of_10)
+    {
+        const auto temp {boost::decimal::detail::remove_trailing_zeros(val)};
+        if (!BOOST_TEST_EQ(temp.trimmed_number, detail::uint128(1)))
+        {
+            std::cerr << "Input Number: " << val
+                      << "\nOutput Number: " << temp.trimmed_number
+                      << "\nZeros removed: " << temp.number_of_removed_zeros << std::endl;
+        }
+    }
+}
+
+int main()
+{
+    test<std::uint32_t>();
+    test<std::uint64_t>();
+    test<boost::decimal::detail::uint128>();
+
+    test_extended();
+
+    return boost::report_errors();
+}

--- a/test/test_remove_trailing_zeros.cpp
+++ b/test/test_remove_trailing_zeros.cpp
@@ -26,9 +26,11 @@ void test()
             const auto temp {boost::decimal::detail::remove_trailing_zeros(static_cast<T>(val))};
             if (!BOOST_TEST_EQ(temp.trimmed_number, T(1)))
             {
+                // LCOV_EXCL_START
                 std::cerr << "Input Number: " << val
                           << "\nOutput Number: " << temp.trimmed_number
                           << "\nZeros removed: " << temp.number_of_removed_zeros << std::endl;
+                // LCOV_EXCL_STOP
             }
         }
     }
@@ -64,9 +66,11 @@ void test_extended()
         const auto temp {boost::decimal::detail::remove_trailing_zeros(val)};
         if (!BOOST_TEST_EQ(temp.trimmed_number, detail::uint128(1)))
         {
+            // LCOV_EXCL_START
             std::cerr << "Input Number: " << val
                       << "\nOutput Number: " << temp.trimmed_number
                       << "\nZeros removed: " << temp.number_of_removed_zeros << std::endl;
+            // LCOV_EXCL_STOP
         }
     }
 }

--- a/tools/granlund-montgomery.py
+++ b/tools/granlund-montgomery.py
@@ -14,22 +14,26 @@ def mod_inverse(a, m):
         return x % m
 
 # Constants
-q0 = 5
-twobt_min_1 = 2**127
+bits = int(128)
+t = int(2)
+
+q = int(10)**t
+q0 = int(q / int(2)**t)
+print("Q0: ", q0)
+twobt_min_t = int(2**(bits - t))
 
 # Calculate the modular inverse
-m0 = mod_inverse(q0, twobt_min_1)
+m0 = int(mod_inverse(q0, twobt_min_t))
 print("M0: ", m0)
 
-p0 = int((q0 * m0 - 1) / twobt_min_1)
+p0 = int((q0 * m0 - 1) / twobt_min_t)
 print("P0: ", p0)
 
 p = int(q0 + p0)
 print("P: ", p)
 
-m = int((twobt_min_1 * p + 1) / q0)
+m = int((twobt_min_t * p + 1) / q0)
 print("M: ", m)
 
-
-threshold_value = int(2**128 / 10 + 1)
+threshold_value = int(2**bits / q + 1)
 print("Threshold Value: ", threshold_value)

--- a/tools/granlund-montgomery.py
+++ b/tools/granlund-montgomery.py
@@ -9,13 +9,13 @@ def extended_euclidean(a, b):
 def mod_inverse(a, m):
     gcd, x, _ = extended_euclidean(a, m)
     if gcd != 1:
-        return None  # Modular inverse doesn't exist
+        return 0  # Modular inverse doesn't exist
     else:
         return x % m
 
 # Constants
 bits = int(128)
-t = int(2)
+t = int(32)
 
 q = int(10)**t
 q0 = int(q / int(2)**t)

--- a/tools/granlund-montgomery.py
+++ b/tools/granlund-montgomery.py
@@ -1,0 +1,35 @@
+def extended_euclidean(a, b):
+    if a == 0:
+        return b, 0, 1
+    gcd, x1, y1 = extended_euclidean(b % a, a)
+    x = y1 - (b // a) * x1
+    y = x1
+    return gcd, x, y
+
+def mod_inverse(a, m):
+    gcd, x, _ = extended_euclidean(a, m)
+    if gcd != 1:
+        return None  # Modular inverse doesn't exist
+    else:
+        return x % m
+
+# Constants
+q0 = 5
+twobt_min_1 = 2**127
+
+# Calculate the modular inverse
+m0 = mod_inverse(q0, twobt_min_1)
+print("M0: ", m0)
+
+p0 = int((q0 * m0 - 1) / twobt_min_1)
+print("P0: ", p0)
+
+p = int(q0 + p0)
+print("P: ", p)
+
+m = int((twobt_min_1 * p + 1) / q0)
+print("M: ", m)
+
+
+threshold_value = int(2**128 / 10 + 1)
+print("Threshold Value: ", threshold_value)


### PR DESCRIPTION
@jk-jeon I thought you might be interested in these results. I took the branchless Granlund-Montgomery from your [repo](https://github.com/jk-jeon/rtz_benchmark/blob/master/source/main.cpp) for `std::uint32_t` and `std::uint64_t` and then adapted a 128-bit case. I also added a test set for every representable power of 10 to see if the result is always 1. I found that in the 32 bit and 64 bit cases an extra step was needed beyond what you had in your repo as it was stopping at 7 and 15 zeros removed respectively. In the 128-bit case I ended up going for two passes since with t = 32, there is no modular inverse so the whole calculation becomes garbage.