### PR TITLE
Fixed width rounding

### DIFF
--- a/doc/decimal/cmath.adoc
+++ b/doc/decimal/cmath.adoc
@@ -458,3 +458,14 @@ constexpr boost::decimal::detail::uint128 frexpd128(decimal128 num, int* expptr)
 
 This function is very similar to https://en.cppreference.com/w/cpp/numeric/math/frexp[frexp], but returns the significand and an integral power of 10 since the `FLT_RADIX` of this type is 10.
 The significand is normalized to the number of digits of precision the type has (e.g. for decimal32 it is [1'000'000, 9'999'999]).
+
+=== trunc_to
+
+[source, c++]
+----
+template <typename Decimal>
+constexpr Decimal trunc_to(Decimal val, int precision = 0);
+----
+
+The function returns the decimal type with number of fractional digits equal to the value of precision.
+`trunc_to` is similar to https://en.cppreference.com/w/cpp/numeric/math/trunc[trunc], and with the default precision argument of 0 it is identical.

--- a/include/boost/decimal/cmath.hpp
+++ b/include/boost/decimal/cmath.hpp
@@ -69,6 +69,7 @@
 #include <boost/decimal/detail/cmath/legendre.hpp>
 #include <boost/decimal/detail/cmath/assoc_legendre.hpp>
 #include <boost/decimal/detail/cmath/ellint_1.hpp>
+#include <boost/decimal/detail/cmath/trunc_to.hpp>
 #include <boost/decimal/numbers.hpp>
 
 // Macros from 3.6.2

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -1318,7 +1318,8 @@ constexpr auto d64_generic_div_impl(detail::decimal64_components lhs, detail::de
 
     // If rhs is greater than we need to offset the significands to get the correct values
     // e.g. 4/8 is 0 but 40/8 yields 5 in integer maths
-    const auto big_sig_lhs {static_cast<unsigned_int128_type>(lhs.sig) * detail::powers_of_10[detail::precision_v<decimal64>]};
+    constexpr auto tens_needed {detail::pow10(static_cast<unsigned_int128_type>(detail::precision_v<decimal64>))};
+    const auto big_sig_lhs {static_cast<unsigned_int128_type>(lhs.sig) * tens_needed};
     lhs.exp -= detail::precision_v<decimal64>;
 
     auto res_sig {big_sig_lhs / static_cast<unsigned_int128_type>(rhs.sig)};

--- a/include/boost/decimal/detail/cmath/trunc.hpp
+++ b/include/boost/decimal/detail/cmath/trunc.hpp
@@ -9,11 +9,14 @@
 #include <boost/decimal/detail/type_traits.hpp>
 #include <boost/decimal/detail/concepts.hpp>
 #include <boost/decimal/detail/config.hpp>
+#include <boost/decimal/detail/fenv_rounding.hpp>
 #include <boost/decimal/detail/cmath/floor.hpp>
 #include <boost/decimal/detail/cmath/ceil.hpp>
+#include <boost/decimal/detail/cmath/frexp10.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 #include <type_traits>
+#include <limits>
 #endif
 
 namespace boost {
@@ -24,6 +27,47 @@ constexpr auto trunc(T val) noexcept
     BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return (val > 0) ? floor(val) : ceil(val);
+}
+
+BOOST_DECIMAL_EXPORT template <typename T>
+constexpr auto trunc(T val, int precision) noexcept
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
+{
+    constexpr auto biggest_val {1 / std::numeric_limits<T>::epsilon()};
+
+    if (precision == 0)
+    {
+        return trunc(val);
+    }
+    else if (isnan(val) || isinf(val) || abs(val) == 0 || val > biggest_val)
+    {
+        return val;
+    }
+
+    int exp {};
+    auto sig {frexp10(val, &exp)};
+    const auto isneg {val < 0};
+    auto sig_dig {detail::num_digits(sig)};
+
+    if (sig_dig <= precision)
+    {
+        return val;
+    }
+
+    if (sig_dig > precision + 1)
+    {
+        const auto digits_to_remove {sig_dig - (precision + 1)};
+        sig /= detail::pow10(static_cast<typename T::significand_type>(digits_to_remove));
+        exp += digits_to_remove;
+        sig_dig -= digits_to_remove;
+    }
+
+    if (sig_dig > precision)
+    {
+        exp += detail::fenv_round(sig, isneg);
+    }
+
+    return {sig, exp, isneg};
 }
 
 } // namespace decimal

--- a/include/boost/decimal/detail/cmath/trunc.hpp
+++ b/include/boost/decimal/detail/cmath/trunc.hpp
@@ -29,47 +29,6 @@ constexpr auto trunc(T val) noexcept
     return (val > 0) ? floor(val) : ceil(val);
 }
 
-BOOST_DECIMAL_EXPORT template <typename T>
-constexpr auto trunc(T val, int precision) noexcept
-    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
-{
-    constexpr auto biggest_val {1 / std::numeric_limits<T>::epsilon()};
-
-    if (precision == 0)
-    {
-        return trunc(val);
-    }
-    else if (isnan(val) || isinf(val) || abs(val) == 0 || val > biggest_val)
-    {
-        return val;
-    }
-
-    int exp {};
-    auto sig {frexp10(val, &exp)};
-    const auto isneg {val < 0};
-    auto sig_dig {detail::num_digits(sig)};
-
-    if (sig_dig <= precision)
-    {
-        return val;
-    }
-
-    if (sig_dig > precision + 1)
-    {
-        const auto digits_to_remove {sig_dig - (precision + 1)};
-        sig /= detail::pow10(static_cast<typename T::significand_type>(digits_to_remove));
-        exp += digits_to_remove;
-        sig_dig -= digits_to_remove;
-    }
-
-    if (sig_dig > precision)
-    {
-        exp += detail::fenv_round(sig, isneg);
-    }
-
-    return {sig, exp, isneg};
-}
-
 } // namespace decimal
 } // namespace boost
 

--- a/include/boost/decimal/detail/cmath/trunc_to.hpp
+++ b/include/boost/decimal/detail/cmath/trunc_to.hpp
@@ -1,0 +1,71 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_DETAIL_CMATH_TRUNC_TO_HPP
+#define BOOST_DECIMAL_DETAIL_CMATH_TRUNC_TO_HPP
+
+#include <boost/decimal/fwd.hpp>
+#include <boost/decimal/detail/type_traits.hpp>
+#include <boost/decimal/detail/concepts.hpp>
+#include <boost/decimal/detail/config.hpp>
+#include <boost/decimal/detail/fenv_rounding.hpp>
+#include <boost/decimal/detail/cmath/floor.hpp>
+#include <boost/decimal/detail/cmath/ceil.hpp>
+#include <boost/decimal/detail/cmath/frexp10.hpp>
+#include <boost/decimal/detail/cmath/trunc.hpp>
+
+#ifndef BOOST_DECIMAL_BUILD_MODULE
+#include <type_traits>
+#include <limits>
+#endif
+
+namespace boost {
+namespace decimal {
+
+BOOST_DECIMAL_EXPORT template <typename T>
+constexpr auto trunc_to(T val, int precision = 0) noexcept
+BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
+{
+    constexpr auto biggest_val {1 / std::numeric_limits<T>::epsilon()};
+
+    if (precision == 0)
+    {
+        return trunc(val);
+    }
+    else if (isnan(val) || isinf(val) || abs(val) == 0 || val > biggest_val)
+    {
+        return val;
+    }
+
+    int exp {};
+    auto sig {frexp10(val, &exp)};
+    const auto isneg {val < 0};
+    auto sig_dig {detail::num_digits(sig)};
+
+    if (sig_dig <= precision)
+    {
+        return val;
+    }
+
+    if (sig_dig > precision + 1)
+    {
+        const auto digits_to_remove {sig_dig - (precision + 1)};
+        sig /= detail::pow10(static_cast<typename T::significand_type>(digits_to_remove));
+        exp += digits_to_remove;
+        sig_dig -= digits_to_remove;
+    }
+
+    if (sig_dig > precision)
+    {
+        exp += detail::fenv_round(sig, isneg);
+    }
+
+    return {sig, exp, isneg};
+}
+
+
+} // namespace decimal
+} // namespace boost
+
+#endif //BOOST_DECIMAL_DETAIL_CMATH_TRUNC_TO_HPP

--- a/include/boost/decimal/detail/cmath/trunc_to.hpp
+++ b/include/boost/decimal/detail/cmath/trunc_to.hpp
@@ -25,7 +25,7 @@ namespace decimal {
 
 BOOST_DECIMAL_EXPORT template <typename T>
 constexpr auto trunc_to(T val, int precision = 0) noexcept
-BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
+    BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     constexpr auto biggest_val {1 / std::numeric_limits<T>::epsilon()};
 

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -352,26 +352,26 @@ constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
            (x >= digits_23) ? 23 :
            (x >= digits_22) ? 22 :
            (x >= digits_21) ? 21 :
-           (x >= powers_of_10[19]) ? 20 :
-           (x >= powers_of_10[18]) ? 19 :
-           (x >= powers_of_10[17]) ? 18 :
-           (x >= powers_of_10[16]) ? 17 :
-           (x >= powers_of_10[15]) ? 16 :
-           (x >= powers_of_10[14]) ? 15 :
-           (x >= powers_of_10[13]) ? 14 :
-           (x >= powers_of_10[12]) ? 13 :
-           (x >= powers_of_10[11]) ? 12 :
-           (x >= powers_of_10[10]) ? 11 :
-           (x >= powers_of_10[9])  ? 10 :
-           (x >= powers_of_10[8])  ?  9 :
-           (x >= powers_of_10[7])  ?  8 :
-           (x >= powers_of_10[6])  ?  7 :
-           (x >= powers_of_10[5])  ?  6 :
-           (x >= powers_of_10[4])  ?  5 :
-           (x >= powers_of_10[3])  ?  4 :
-           (x >= powers_of_10[2])  ?  3 :
-           (x >= powers_of_10[1])  ?  2 :
-           (x >= powers_of_10[0])  ?  1 : 0;
+           (x >= impl::powers_of_10[19]) ? 20 :
+           (x >= impl::powers_of_10[18]) ? 19 :
+           (x >= impl::powers_of_10[17]) ? 18 :
+           (x >= impl::powers_of_10[16]) ? 17 :
+           (x >= impl::powers_of_10[15]) ? 16 :
+           (x >= impl::powers_of_10[14]) ? 15 :
+           (x >= impl::powers_of_10[13]) ? 14 :
+           (x >= impl::powers_of_10[12]) ? 13 :
+           (x >= impl::powers_of_10[11]) ? 12 :
+           (x >= impl::powers_of_10[10]) ? 11 :
+           (x >= impl::powers_of_10[9])  ? 10 :
+           (x >= impl::powers_of_10[8])  ?  9 :
+           (x >= impl::powers_of_10[7])  ?  8 :
+           (x >= impl::powers_of_10[6])  ?  7 :
+           (x >= impl::powers_of_10[5])  ?  6 :
+           (x >= impl::powers_of_10[4])  ?  5 :
+           (x >= impl::powers_of_10[3])  ?  4 :
+           (x >= impl::powers_of_10[2])  ?  3 :
+           (x >= impl::powers_of_10[1])  ?  2 :
+           (x >= impl::powers_of_10[0])  ?  1 : 0;
 }
 
 #endif // constexpr arrays

--- a/include/boost/decimal/detail/power_tables.hpp
+++ b/include/boost/decimal/detail/power_tables.hpp
@@ -16,18 +16,23 @@ namespace boost {
 namespace decimal {
 namespace detail {
 
+namespace impl {
+
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t powers_of_10[20] =
 {
-         UINT64_C(1), UINT64_C(10), UINT64_C(100), UINT64_C(1000), UINT64_C(10000), UINT64_C(100000), UINT64_C(1000000),
-         UINT64_C(10000000), UINT64_C(100000000), UINT64_C(1000000000), UINT64_C(10000000000), UINT64_C(100000000000),
-         UINT64_C(1000000000000), UINT64_C(10000000000000), UINT64_C(100000000000000), UINT64_C(1000000000000000),
-         UINT64_C(10000000000000000), UINT64_C(100000000000000000), UINT64_C(1000000000000000000), UINT64_C(10000000000000000000)
- };
+    UINT64_C(1), UINT64_C(10), UINT64_C(100), UINT64_C(1000), UINT64_C(10000), UINT64_C(100000), UINT64_C(1000000),
+    UINT64_C(10000000), UINT64_C(100000000), UINT64_C(1000000000), UINT64_C(10000000000), UINT64_C(100000000000),
+    UINT64_C(1000000000000), UINT64_C(10000000000000), UINT64_C(100000000000000), UINT64_C(1000000000000000),
+    UINT64_C(10000000000000000), UINT64_C(100000000000000000), UINT64_C(1000000000000000000),
+    UINT64_C(10000000000000000000)
+};
+
+} // namespace impl
 
 template <typename T>
 constexpr auto pow10(T n) noexcept -> T
 {
-    return static_cast<T>(powers_of_10[static_cast<std::size_t>(n)]);
+    return static_cast<T>(impl::powers_of_10[static_cast<std::size_t>(n)]);
 }
 
 template <>
@@ -36,12 +41,12 @@ constexpr auto pow10(detail::uint128 n) noexcept -> detail::uint128
     detail::uint128 res {1};
     if (n <= 19)
     {
-        res = powers_of_10[static_cast<std::size_t>(n)];
+        res = impl::powers_of_10[static_cast<std::size_t>(n)];
     }
     else
     {
-        res = powers_of_10[static_cast<std::size_t>(19)];
-        res *= powers_of_10[static_cast<std::size_t>(n - 19)];
+        res = impl::powers_of_10[static_cast<std::size_t>(19)];
+        res *= impl::powers_of_10[static_cast<std::size_t>(n - 19)];
     }
 
     return res;
@@ -55,12 +60,12 @@ constexpr auto pow10(detail::uint128_t n) noexcept -> detail::uint128_t
     detail::uint128_t res {1};
     if (n <= 19)
     {
-        res = powers_of_10[static_cast<std::size_t>(n)];
+        res = impl::powers_of_10[static_cast<std::size_t>(n)];
     }
     else
     {
-        res = powers_of_10[static_cast<std::size_t>(19)];
-        res *= powers_of_10[static_cast<std::size_t>(n - 19)];
+        res = impl::powers_of_10[static_cast<std::size_t>(19)];
+        res *= impl::powers_of_10[static_cast<std::size_t>(n - 19)];
     }
 
     return res;

--- a/include/boost/decimal/detail/shrink_significand.hpp
+++ b/include/boost/decimal/detail/shrink_significand.hpp
@@ -30,7 +30,7 @@ constexpr auto shrink_significand(Integer sig, std::int32_t& exp) noexcept -> Ta
 
     if (sig_dig > max_digits)
     {
-        unsigned_sig /= static_cast<Unsigned_Integer>(powers_of_10[static_cast<std::size_t>(sig_dig - max_digits)]);
+        unsigned_sig /= pow10(static_cast<Unsigned_Integer>(sig_dig - max_digits));
         exp += sig_dig - max_digits;
     }
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -95,6 +95,7 @@ run test_exp.cpp ;
 compile-fail test_explicit_floats.cpp ;
 run test_expm1.cpp ;
 run test_fenv.cpp ;
+run test_fixed_width_trunc.cpp ;
 run test_float_conversion.cpp ;
 run-fail test_fprintf.cpp ;
 run test_frexp_ldexp.cpp ;

--- a/test/test_fixed_width_trunc.cpp
+++ b/test/test_fixed_width_trunc.cpp
@@ -1,0 +1,59 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <limits>
+
+using namespace boost::decimal;
+
+template <typename T>
+void test()
+{
+    constexpr T test_val {UINT32_C(1234567), 0};
+    constexpr T validation_val_1 {UINT32_C(1), 6};
+    constexpr T validation_val_2 {UINT32_C(12), 5};
+    constexpr T validation_val_3 {UINT32_C(123), 4};
+    constexpr T validation_val_4 {UINT32_C(1235), 3};
+    constexpr T validation_val_5 {UINT32_C(12346), 2};
+    constexpr T validation_val_6 {UINT32_C(123457), 1};
+    constexpr T validation_val_7 {test_val};
+
+    BOOST_TEST_EQ(trunc(test_val, 0), trunc(test_val));
+    BOOST_TEST_EQ(trunc(test_val, 1), validation_val_1);
+    BOOST_TEST_EQ(trunc(test_val, 2), validation_val_2);
+    BOOST_TEST_EQ(trunc(test_val, 3), validation_val_3);
+    BOOST_TEST_EQ(trunc(test_val, 4), validation_val_4);
+    BOOST_TEST_EQ(trunc(test_val, 5), validation_val_5);
+    BOOST_TEST_EQ(trunc(test_val, 6), validation_val_6);
+    BOOST_TEST_EQ(trunc(test_val, 7), validation_val_7);
+    BOOST_TEST_EQ(trunc(test_val, 100), test_val);
+
+    // Non-finite values
+    for (int i = 0; i < 10; ++i)
+    {
+        BOOST_TEST(isinf(trunc(std::numeric_limits<T>::infinity(), i)));
+        BOOST_TEST(isnan(trunc(std::numeric_limits<T>::quiet_NaN(), i)));
+        BOOST_TEST(isnan(trunc(std::numeric_limits<T>::signaling_NaN(), i)));
+        BOOST_TEST_EQ(trunc(T{0}, i), T{0});
+    }
+
+    // Big value
+    constexpr T big_val {1, 20};
+    for (int i = 0; i < 10; ++i)
+    {
+        BOOST_TEST_EQ(trunc(big_val, i), big_val);
+    }
+}
+
+int main()
+{
+    test<decimal32>();
+    test<decimal64>();
+    test<decimal128>();
+
+    test<decimal32_fast>();
+
+    return boost::report_errors();
+}

--- a/test/test_fixed_width_trunc.cpp
+++ b/test/test_fixed_width_trunc.cpp
@@ -20,30 +20,30 @@ void test()
     constexpr T validation_val_6 {UINT32_C(123457), 1};
     constexpr T validation_val_7 {test_val};
 
-    BOOST_TEST_EQ(trunc(test_val, 0), trunc(test_val));
-    BOOST_TEST_EQ(trunc(test_val, 1), validation_val_1);
-    BOOST_TEST_EQ(trunc(test_val, 2), validation_val_2);
-    BOOST_TEST_EQ(trunc(test_val, 3), validation_val_3);
-    BOOST_TEST_EQ(trunc(test_val, 4), validation_val_4);
-    BOOST_TEST_EQ(trunc(test_val, 5), validation_val_5);
-    BOOST_TEST_EQ(trunc(test_val, 6), validation_val_6);
-    BOOST_TEST_EQ(trunc(test_val, 7), validation_val_7);
-    BOOST_TEST_EQ(trunc(test_val, 100), test_val);
+    BOOST_TEST_EQ(trunc_to(test_val, 0), trunc_to(test_val));
+    BOOST_TEST_EQ(trunc_to(test_val, 1), validation_val_1);
+    BOOST_TEST_EQ(trunc_to(test_val, 2), validation_val_2);
+    BOOST_TEST_EQ(trunc_to(test_val, 3), validation_val_3);
+    BOOST_TEST_EQ(trunc_to(test_val, 4), validation_val_4);
+    BOOST_TEST_EQ(trunc_to(test_val, 5), validation_val_5);
+    BOOST_TEST_EQ(trunc_to(test_val, 6), validation_val_6);
+    BOOST_TEST_EQ(trunc_to(test_val, 7), validation_val_7);
+    BOOST_TEST_EQ(trunc_to(test_val, 100), test_val);
 
     // Non-finite values
     for (int i = 0; i < 10; ++i)
     {
-        BOOST_TEST(isinf(trunc(std::numeric_limits<T>::infinity(), i)));
-        BOOST_TEST(isnan(trunc(std::numeric_limits<T>::quiet_NaN(), i)));
-        BOOST_TEST(isnan(trunc(std::numeric_limits<T>::signaling_NaN(), i)));
-        BOOST_TEST_EQ(trunc(T{0}, i), T{0});
+        BOOST_TEST(isinf(trunc_to(std::numeric_limits<T>::infinity(), i)));
+        BOOST_TEST(isnan(trunc_to(std::numeric_limits<T>::quiet_NaN(), i)));
+        BOOST_TEST(isnan(trunc_to(std::numeric_limits<T>::signaling_NaN(), i)));
+        BOOST_TEST_EQ(trunc_to(T{0}, i), T{0});
     }
 
     // Big value
     constexpr T big_val {1, 20};
     for (int i = 0; i < 10; ++i)
     {
-        BOOST_TEST_EQ(trunc(big_val, i), big_val);
+        BOOST_TEST_EQ(trunc_to(big_val, i), big_val);
     }
 }
 


### PR DESCRIPTION
Closes: #565 

@ckormanyos This one was by request from the discussion on the ML. I am open to a better name than overloading `trunc` even though that's what it does; truncates to a fixed number of decimal places (with appropriate rounding).