### PR TITLE
Offer fast math macro

### DIFF
--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -828,9 +828,9 @@ constexpr auto operator-(decimal32 rhs) noexcept-> decimal32
 // NOLINTNEXTLINE : If addition is actually subtraction than change operator and vice versa
 constexpr auto operator+(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32 zero {0, 0};
 
-    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto res {detail::check_non_finite(lhs, rhs)};
     if (res != zero)
     {
@@ -965,9 +965,9 @@ constexpr auto decimal32::operator+=(Decimal rhs) noexcept
 // NOLINTNEXTLINE : If subtraction is actually addition than use operator+ and vice versa
 constexpr auto operator-(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32 zero {0, 0};
 
-    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto res {detail::check_non_finite(lhs, rhs)};
     if (res != zero)
     {

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -830,11 +830,13 @@ constexpr auto operator+(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
     constexpr decimal32 zero {0, 0};
 
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto res {detail::check_non_finite(lhs, rhs)};
     if (res != zero)
     {
         return res;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && rhs.isneg())
@@ -870,10 +872,12 @@ template <typename Integer>
 constexpr auto operator+(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && (rhs < 0))
@@ -963,11 +967,13 @@ constexpr auto operator-(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
     constexpr decimal32 zero {0, 0};
 
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto res {detail::check_non_finite(lhs, rhs)};
     if (res != zero)
     {
         return res;
     }
+    #endif
 
     if (!lhs.isneg() && rhs.isneg())
     {
@@ -995,10 +1001,12 @@ template <typename Integer>
 constexpr auto operator-(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(lhs) || isnan(lhs))
     {
         return lhs;
     }
+    #endif
 
     if (!lhs.isneg() && (rhs < 0))
     {
@@ -1029,10 +1037,12 @@ template <typename Integer>
 constexpr auto operator-(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(rhs) || isnan(rhs))
     {
         return rhs;
     }
+    #endif
 
     if (lhs >= 0 && rhs.isneg())
     {
@@ -1139,6 +1149,7 @@ constexpr auto operator!=(Integer lhs, decimal32 rhs) noexcept
 
 constexpr auto operator<(decimal32 lhs, decimal32 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs) ||
         (!lhs.isneg() && rhs.isneg()))
     {
@@ -1152,6 +1163,16 @@ constexpr auto operator<(decimal32 lhs, decimal32 rhs) noexcept -> bool
     {
         return !rhs.isneg();
     }
+    #else
+    if (!lhs.isneg() && rhs.isneg())
+    {
+        return false;
+    }
+    else if (lhs.isneg() && !rhs.isneg())
+    {
+        return true;
+    }
+    #endif
 
     return less_parts_impl(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
                            rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
@@ -1168,20 +1189,24 @@ template <typename Integer>
 constexpr auto operator<(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !less_impl(rhs, lhs) && lhs != rhs;
 }
 
 constexpr auto operator<=(decimal32 lhs, decimal32 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1190,10 +1215,12 @@ template <typename Integer>
 constexpr auto operator<=(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1202,10 +1229,12 @@ template <typename Integer>
 constexpr auto operator<=(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1219,10 +1248,12 @@ template <typename Integer>
 constexpr auto operator>(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return rhs < lhs;
 }
@@ -1231,20 +1262,24 @@ template <typename Integer>
 constexpr auto operator>(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return rhs < lhs;
 }
 
 constexpr auto operator>=(decimal32 lhs, decimal32 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -1253,10 +1288,12 @@ template <typename Integer>
 constexpr auto operator>=(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -1265,10 +1302,12 @@ template <typename Integer>
 constexpr auto operator>=(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -1435,6 +1474,7 @@ template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, b
 #endif
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal32::decimal32(Float val) noexcept
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (val != val)
     {
         *this = boost::decimal::from_bits(boost::decimal::detail::d32_nan_mask);
@@ -1444,6 +1484,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal32::decimal32(Float val) noexcept
         *this = boost::decimal::from_bits(boost::decimal::detail::d32_inf_mask);
     }
     else
+    #endif
     {
         const auto components {detail::ryu::floating_point_to_fd128(val)};
 
@@ -1453,11 +1494,13 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal32::decimal32(Float val) noexcept
                   << "\nSign: " << components.sign << std::endl;
         #endif
 
+        #ifndef BOOST_DECIMAL_FAST_MATH
         if (components.exponent > detail::emax)
         {
             *this = boost::decimal::from_bits(boost::decimal::detail::d32_inf_mask);
         }
         else
+        #endif
         {
             *this = decimal32 {components.mantissa, components.exponent, components.sign};
         }
@@ -1602,6 +1645,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR auto to_bits(decimal32 rhs) noexcept -> std::uint3
 
 constexpr auto operator*(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32 zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -1609,6 +1653,7 @@ constexpr auto operator*(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
     {
         return res;
     }
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1627,10 +1672,12 @@ template <typename Integer>
 constexpr auto operator*(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1681,6 +1728,7 @@ constexpr auto decimal32::operator*=(Decimal rhs) noexcept
 
 constexpr auto div_impl(decimal32 lhs, decimal32 rhs, decimal32& q, decimal32& r) noexcept -> void
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal32 zero {0, 0};
     constexpr decimal32 nan {boost::decimal::from_bits(boost::decimal::detail::d32_snan_mask)};
@@ -1725,6 +1773,9 @@ constexpr auto div_impl(decimal32 lhs, decimal32 rhs, decimal32& q, decimal32& r
         default:
             static_cast<void>(rhs);
     }
+    #else
+    static_cast<void>(r);
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1772,6 +1823,7 @@ template <typename Integer>
 constexpr auto operator/(decimal32 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal32 zero {0, 0};
     constexpr decimal32 nan {boost::decimal::from_bits(boost::decimal::detail::d32_snan_mask)};
@@ -1797,6 +1849,7 @@ constexpr auto operator/(decimal32 lhs, Integer rhs) noexcept
     {
         return sign ? -inf : inf;
     }
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1816,6 +1869,7 @@ template <typename Integer>
 constexpr auto operator/(Integer lhs, decimal32 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal32 zero {0, 0};
     constexpr decimal32 nan {boost::decimal::from_bits(boost::decimal::detail::d32_snan_mask)};
@@ -1839,6 +1893,7 @@ constexpr auto operator/(Integer lhs, decimal32 rhs) noexcept
         default:
             static_cast<void>(lhs);
     }
+    #endif
 
     auto sig_rhs {rhs.full_significand()};
     auto exp_rhs {rhs.biased_exponent()};
@@ -2054,6 +2109,7 @@ constexpr auto operator~(decimal32 lhs) noexcept -> decimal32
 // The samequantum functions raise no exception.
 constexpr auto samequantumd32(decimal32 lhs, decimal32 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto lhs_fp {fpclassify(lhs)};
     const auto rhs_fp {fpclassify(rhs)};
 
@@ -2065,6 +2121,7 @@ constexpr auto samequantumd32(decimal32 lhs, decimal32 rhs) noexcept -> bool
     {
         return false;
     }
+    #endif
 
     return lhs.unbiased_exponent() == rhs.unbiased_exponent();
 }
@@ -2074,10 +2131,12 @@ constexpr auto samequantumd32(decimal32 lhs, decimal32 rhs) noexcept -> bool
 // Otherwise, a domain error occurs and INT_MIN is returned.
 constexpr auto quantexpd32(decimal32 x) noexcept -> int
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (!isfinite(x))
     {
         return INT_MIN;
     }
+    #endif
 
     return static_cast<int>(x.unbiased_exponent());
 }
@@ -2095,6 +2154,7 @@ constexpr auto quantexpd32(decimal32 x) noexcept -> int
 // The quantize functions do not signal underflow.
 constexpr auto quantized32(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Return the correct type of nan
     if (isnan(lhs))
     {
@@ -2114,18 +2174,21 @@ constexpr auto quantized32(decimal32 lhs, decimal32 rhs) noexcept -> decimal32
     {
         return lhs;
     }
+    #endif
 
     return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
 }
 
 constexpr auto scalblnd32(decimal32 num, long exp) noexcept -> decimal32
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32 zero {0, 0};
 
     if (num == zero || exp == 0 || isinf(num) || isnan(num))
     {
         return num;
     }
+    #endif
 
     num.edit_exponent(num.biased_exponent() + exp);
 

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -1380,9 +1380,9 @@ constexpr decimal32_fast::operator Decimal() const noexcept
 
 constexpr auto scalblnd32f(decimal32_fast num, long exp) noexcept -> decimal32_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32_fast zero {0, 0};
 
-    #ifndef BOOST_DECIMAL_FAST_MATH
     if (num == zero || exp == 0 || isinf(num) || isnan(num))
     {
         return num;

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -405,6 +405,7 @@ constexpr decimal32_fast::decimal32_fast(Integer val) noexcept
 template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, bool>>
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal32_fast::decimal32_fast(Float val) noexcept
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (val != val)
     {
         significand_ = detail::d32_fast_qnan;
@@ -414,6 +415,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal32_fast::decimal32_fast(Float val) noexcept
         significand_ = detail::d32_fast_inf;
     }
     else
+    #endif
     {
         const auto components {detail::ryu::floating_point_to_fd128(val)};
         *this = decimal32_fast {components.mantissa, components.exponent, components.sign};
@@ -468,10 +470,12 @@ constexpr auto isnormal(decimal32_fast val) noexcept -> bool
 
 constexpr auto operator==(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return lhs.sign_ == rhs.sign_ &&
            lhs.exponent_ == rhs.exponent_ &&
@@ -485,6 +489,7 @@ constexpr auto operator!=(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bo
 
 constexpr auto operator<(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs) ||
         (!lhs.isneg() && rhs.isneg()))
     {
@@ -502,6 +507,16 @@ constexpr auto operator<(decimal32_fast lhs, decimal32_fast rhs) noexcept -> boo
     {
         return signbit(rhs);
     }
+    #else
+    if (!lhs.isneg() && rhs.isneg())
+    {
+        return false;
+    }
+    else if (lhs.isneg() && !rhs.isneg())
+    {
+        return true;
+    }
+    #endif
 
     if (lhs.significand_ == 0 || rhs.significand_ == 0)
     {
@@ -527,10 +542,12 @@ constexpr auto operator<(decimal32_fast lhs, decimal32_fast rhs) noexcept -> boo
 
 constexpr auto operator<=(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -542,10 +559,12 @@ constexpr auto operator>(decimal32_fast lhs, decimal32_fast rhs) noexcept -> boo
 
 constexpr auto operator>=(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -589,49 +608,77 @@ template <typename Integer>
 constexpr auto operator<(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(rhs) ? false : !less_impl(rhs, lhs) && lhs != rhs;
+    #else
+    return !less_impl(rhs, lhs) && lhs != rhs;
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator<=(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(lhs) ? false : !(rhs < lhs);
+    #else
+    return !(rhs < lhs);
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator<=(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(rhs) ? false : !(rhs < lhs);
+    #else
+    return !(rhs < lhs);
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator>(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(lhs) ? false : rhs < lhs;
+    #else
+    return rhs < lhs;
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator>(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(rhs) ? false : rhs < lhs;
+    #else
+    return rhs < lhs;
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator>=(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(lhs) ? false : !(lhs < rhs);
+    #else
+    return !(lhs < rhs);
+    #endif
 }
 
 template <typename Integer>
 constexpr auto operator>=(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     return isnan(rhs) ? false : !(lhs < rhs);
+    #else
+    return !(lhs < rhs);
+    #endif
 }
 
 #ifdef BOOST_DECIMAL_HAS_SPACESHIP_OPERATOR
@@ -709,6 +756,7 @@ constexpr auto operator-(decimal32_fast rhs) noexcept -> decimal32_fast
 
 constexpr auto operator+(decimal32_fast lhs, decimal32_fast rhs) noexcept -> decimal32_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32_fast zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -716,6 +764,7 @@ constexpr auto operator+(decimal32_fast lhs, decimal32_fast rhs) noexcept -> dec
     {
         return res;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && rhs.isneg())
@@ -746,10 +795,12 @@ template <typename Integer>
 constexpr auto operator+(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && (rhs < 0))
@@ -798,6 +849,7 @@ constexpr auto operator+(Integer lhs, decimal32_fast rhs) noexcept
 
 constexpr auto operator-(decimal32_fast lhs, decimal32_fast rhs) noexcept -> decimal32_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32_fast zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -805,6 +857,7 @@ constexpr auto operator-(decimal32_fast lhs, decimal32_fast rhs) noexcept -> dec
     {
         return res;
     }
+    #endif
 
     if (!lhs.isneg() && rhs.isneg())
     {
@@ -826,10 +879,12 @@ template <typename Integer>
 constexpr auto operator-(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(lhs) || isnan(lhs))
     {
         return lhs;
     }
+    #endif
 
     if (!lhs.isneg() && (rhs < 0))
     {
@@ -858,10 +913,12 @@ template <typename Integer>
 constexpr auto operator-(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(rhs) || isnan(rhs))
     {
         return rhs;
     }
+    #endif
 
     if (lhs >= 0 && rhs.isneg())
     {
@@ -889,6 +946,7 @@ constexpr auto operator-(Integer lhs, decimal32_fast rhs) noexcept
 
 constexpr auto operator*(decimal32_fast lhs, decimal32_fast rhs) noexcept -> decimal32_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal32_fast zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -896,6 +954,7 @@ constexpr auto operator*(decimal32_fast lhs, decimal32_fast rhs) noexcept -> dec
     {
         return res;
     }
+    #endif
 
     const auto result {detail::mul_impl<detail::decimal32_fast_components>(
             lhs.significand_, lhs.biased_exponent(), lhs.sign_,
@@ -909,10 +968,12 @@ template <typename Integer>
 constexpr auto operator*(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     auto lhs_components {detail::decimal32_fast_components{lhs.significand_, lhs.biased_exponent(), lhs.sign_}};
 
@@ -939,6 +1000,7 @@ constexpr auto operator*(Integer lhs, decimal32_fast rhs) noexcept
 
 constexpr auto div_impl(decimal32_fast lhs, decimal32_fast rhs, decimal32_fast& q, decimal32_fast& r) noexcept -> void
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const bool sign {lhs.isneg() != rhs.isneg()};
 
     constexpr decimal32_fast zero {0, 0};
@@ -982,6 +1044,9 @@ constexpr auto div_impl(decimal32_fast lhs, decimal32_fast rhs, decimal32_fast& 
         default:
             static_cast<void>(rhs);
     }
+    #else
+    static_cast<void>(r);
+    #endif
 
     #ifdef BOOST_DECIMAL_DEBUG
     std::cerr << "sig lhs: " << sig_lhs
@@ -1021,6 +1086,7 @@ template <typename Integer>
 constexpr auto operator/(decimal32_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal32_fast zero {0, 0};
     constexpr decimal32_fast nan {direct_init(detail::d32_fast_qnan, UINT8_C(0), false)};
@@ -1046,6 +1112,7 @@ constexpr auto operator/(decimal32_fast lhs, Integer rhs) noexcept
     {
         return sign ? -inf : inf;
     }
+    #endif
 
     const detail::decimal32_fast_components lhs_components {lhs.significand_, lhs.biased_exponent(), lhs.sign_};
     std::int32_t exp_rhs {};
@@ -1061,6 +1128,7 @@ template <typename Integer>
 constexpr auto operator/(Integer lhs, decimal32_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal32_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal32_fast zero {0, 0};
     constexpr decimal32_fast nan {direct_init(detail::d32_fast_qnan, UINT8_C(0), false)};
@@ -1084,6 +1152,7 @@ constexpr auto operator/(Integer lhs, decimal32_fast rhs) noexcept
         default:
             static_cast<void>(lhs);
     }
+    #endif
 
     std::int32_t lhs_exp {};
     const auto lhs_sig {detail::make_positive_unsigned(detail::shrink_significand<decimal32_fast::significand_type>(lhs, lhs_exp))};
@@ -1313,10 +1382,12 @@ constexpr auto scalblnd32f(decimal32_fast num, long exp) noexcept -> decimal32_f
 {
     constexpr decimal32_fast zero {0, 0};
 
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (num == zero || exp == 0 || isinf(num) || isnan(num))
     {
         return num;
     }
+    #endif
 
     num = decimal32_fast(num.significand_, num.biased_exponent() + exp, num.sign_);
 
@@ -1340,6 +1411,7 @@ constexpr auto copysignd32f(decimal32_fast mag, decimal32_fast sgn) noexcept -> 
 // The samequantum functions raise no exception.
 constexpr auto samequantumd32f(decimal32_fast lhs, decimal32_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto lhs_fp {fpclassify(lhs)};
     const auto rhs_fp {fpclassify(rhs)};
 
@@ -1351,6 +1423,7 @@ constexpr auto samequantumd32f(decimal32_fast lhs, decimal32_fast rhs) noexcept 
     {
         return false;
     }
+    #endif
 
     return lhs.unbiased_exponent() == rhs.unbiased_exponent();
 }
@@ -1359,10 +1432,12 @@ constexpr auto samequantumd32f(decimal32_fast lhs, decimal32_fast rhs) noexcept 
 // Otherwise, a domain error occurs and INT_MIN is returned.
 constexpr auto quantexpd32f(decimal32_fast x) noexcept -> int
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (!isfinite(x))
     {
         return INT_MIN;
     }
+    #endif
 
     return static_cast<int>(x.unbiased_exponent());
 }
@@ -1379,6 +1454,7 @@ constexpr auto quantexpd32f(decimal32_fast x) noexcept -> int
 // The quantize functions do not signal underflow.
 constexpr auto quantized32f(decimal32_fast lhs, decimal32_fast rhs) noexcept -> decimal32_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Return the correct type of nan
     if (isnan(lhs))
     {
@@ -1398,6 +1474,7 @@ constexpr auto quantized32f(decimal32_fast lhs, decimal32_fast rhs) noexcept -> 
     {
         return lhs;
     }
+    #endif
 
     return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
 }

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -773,6 +773,7 @@ template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, b
 #endif
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal64::decimal64(Float val) noexcept
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (val != val)
     {
         *this = from_bits(detail::d64_nan_mask);
@@ -782,6 +783,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal64::decimal64(Float val) noexcept
         *this = from_bits(detail::d64_inf_mask);
     }
     else
+    #endif
     {
         const auto components {detail::ryu::floating_point_to_fd128(val)};
 
@@ -1097,6 +1099,7 @@ constexpr auto operator-(decimal64 rhs) noexcept-> decimal64
 
 constexpr auto d64_div_impl(decimal64 lhs, decimal64 rhs, decimal64& q, decimal64& r) noexcept -> void
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64 zero {0, 0};
     constexpr decimal64 nan {boost::decimal::from_bits(boost::decimal::detail::d64_snan_mask)};
@@ -1141,6 +1144,9 @@ constexpr auto d64_div_impl(decimal64 lhs, decimal64 rhs, decimal64& q, decimal6
         default:
             static_cast<void>(rhs);
     }
+    #else
+    static_cast<void>(r);
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1177,6 +1183,7 @@ constexpr auto d64_mod_impl(decimal64 lhs, decimal64 rhs, const decimal64& q, de
 
 constexpr auto operator+(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64 zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -1184,6 +1191,7 @@ constexpr auto operator+(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
     {
         return res;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && rhs.isneg())
@@ -1220,10 +1228,12 @@ template <typename Integer>
 constexpr auto operator+(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && (rhs < 0))
@@ -1284,6 +1294,7 @@ constexpr auto operator+(Integer lhs, decimal64 rhs) noexcept
 // NOLINTNEXTLINE : If subtraction is actually addition than use operator+ and vice versa
 constexpr auto operator-(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64 zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -1291,6 +1302,7 @@ constexpr auto operator-(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
     {
         return res;
     }
+    #endif
 
     if (!lhs.isneg() && rhs.isneg())
     {
@@ -1318,10 +1330,12 @@ template <typename Integer>
 constexpr auto operator-(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(lhs) || isnan(lhs))
     {
         return lhs;
     }
+    #endif
 
     if (!lhs.isneg() && (rhs < 0))
     {
@@ -1352,10 +1366,12 @@ template <typename Integer>
 constexpr auto operator-(Integer lhs, decimal64 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(rhs) || isnan(rhs))
     {
         return rhs;
     }
+    #endif
 
     if (lhs >= 0 && rhs.isneg())
     {
@@ -1384,6 +1400,7 @@ constexpr auto operator-(Integer lhs, decimal64 rhs) noexcept
 
 constexpr auto operator*(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64 zero {0, 0};
 
     const auto non_finite {detail::check_non_finite(lhs, rhs)};
@@ -1391,6 +1408,7 @@ constexpr auto operator*(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
     {
         return non_finite;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1410,10 +1428,12 @@ template <typename Integer>
 constexpr auto operator*(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1452,6 +1472,7 @@ template <typename Integer>
 constexpr auto operator/(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64 zero {0, 0};
     constexpr decimal64 nan {boost::decimal::from_bits(boost::decimal::detail::d64_snan_mask)};
@@ -1477,6 +1498,7 @@ constexpr auto operator/(decimal64 lhs, Integer rhs) noexcept
     {
         return sign ? -inf : inf;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1498,6 +1520,7 @@ template <typename Integer>
 constexpr auto operator/(Integer lhs, decimal64 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64 zero {0, 0};
     constexpr decimal64 inf {boost::decimal::from_bits(boost::decimal::detail::d64_inf_mask)};
@@ -1521,6 +1544,7 @@ constexpr auto operator/(Integer lhs, decimal64 rhs) noexcept
         default:
             static_cast<void>(lhs);
     }
+    #endif
 
     auto rhs_sig {rhs.full_significand()};
     auto rhs_exp {rhs.biased_exponent()};
@@ -1665,11 +1689,13 @@ constexpr auto decimal64::operator%=(decimal64 rhs) noexcept -> decimal64&
 
 constexpr auto operator==(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check for IEEE requirement that nan != nan
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return equal_parts_impl<decimal64>(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
                                        rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
@@ -1710,6 +1736,7 @@ constexpr auto operator!=(Integer lhs, decimal64 rhs) noexcept
 
 constexpr auto operator<(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs) ||
         (!lhs.isneg() && rhs.isneg()))
     {
@@ -1723,6 +1750,16 @@ constexpr auto operator<(decimal64 lhs, decimal64 rhs) noexcept -> bool
     {
         return !rhs.isneg();
     }
+    #else
+    if (!lhs.isneg() && rhs.isneg())
+    {
+        return false;
+    }
+    else if (lhs.isneg() && !rhs.isneg())
+    {
+        return true;
+    }
+    #endif
 
     return less_parts_impl<decimal64>(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
                                       rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
@@ -1739,20 +1776,24 @@ template <typename Integer>
 constexpr auto operator<(Integer lhs, decimal64 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !less_impl(rhs, lhs) && lhs != rhs;
 }
 
 constexpr auto operator<=(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1761,10 +1802,12 @@ template <typename Integer>
 constexpr auto operator<=(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1773,10 +1816,12 @@ template <typename Integer>
 constexpr auto operator<=(Integer lhs, decimal64 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -1802,10 +1847,12 @@ constexpr auto operator>(Integer lhs, decimal64 rhs) noexcept
 
 constexpr auto operator>=(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -1814,10 +1861,12 @@ template <typename Integer>
 constexpr auto operator>=(decimal64 lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -1826,10 +1875,12 @@ template <typename Integer>
 constexpr auto operator>=(Integer lhs, decimal64 rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -2003,6 +2054,7 @@ constexpr auto operator~(decimal64 lhs) noexcept -> decimal64
 // The samequantum functions raise no exception.
 constexpr auto samequantumd64(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     const auto lhs_fp {fpclassify(lhs)};
     const auto rhs_fp {fpclassify(rhs)};
 
@@ -2014,6 +2066,7 @@ constexpr auto samequantumd64(decimal64 lhs, decimal64 rhs) noexcept -> bool
     {
         return false;
     }
+    #endif
 
     return lhs.unbiased_exponent() == rhs.unbiased_exponent();
 }
@@ -2023,10 +2076,12 @@ constexpr auto samequantumd64(decimal64 lhs, decimal64 rhs) noexcept -> bool
 // Otherwise, a domain error occurs and INT_MIN is returned.
 constexpr auto quantexpd64(decimal64 x) noexcept -> int
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (!isfinite(x))
     {
         return INT_MIN;
     }
+    #endif
 
     return static_cast<int>(x.unbiased_exponent());
 }
@@ -2044,6 +2099,7 @@ constexpr auto quantexpd64(decimal64 x) noexcept -> int
 // The quantize functions do not signal underflow.
 constexpr auto quantized64(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Return the correct type of nan
     if (isnan(lhs))
     {
@@ -2063,18 +2119,21 @@ constexpr auto quantized64(decimal64 lhs, decimal64 rhs) noexcept -> decimal64
     {
         return lhs;
     }
+    #endif
 
     return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
 }
 
 constexpr auto scalblnd64(decimal64 num, long exp) noexcept -> decimal64
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64 zero {0, 0};
 
     if (num == zero || exp == 0 || isinf(num) || isnan(num))
     {
         return num;
     }
+    #endif
 
     num.edit_exponent(num.biased_exponent() + exp);
 

--- a/include/boost/decimal/decimal64_fast.hpp
+++ b/include/boost/decimal/decimal64_fast.hpp
@@ -425,6 +425,7 @@ template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, b
 #endif
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_fast::decimal64_fast(Float val) noexcept
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (val != val)
     {
         significand_ = detail::d64_fast_qnan;
@@ -434,6 +435,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_fast::decimal64_fast(Float val) noexcept
         significand_ = detail::d64_fast_inf;
     }
     else
+    #endif
     {
         const auto components {detail::ryu::floating_point_to_fd128(val)};
         *this = decimal64_fast {components.mantissa, components.exponent, components.sign};
@@ -489,10 +491,12 @@ constexpr auto isnormal(decimal64_fast val) noexcept -> bool
 
 constexpr auto operator==(decimal64_fast lhs, decimal64_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return equal_parts_impl(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
                             rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
@@ -533,6 +537,7 @@ constexpr auto operator!=(Integer lhs, decimal64_fast rhs) noexcept
 
 constexpr auto operator<(decimal64_fast lhs, decimal64_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs) ||
         (!lhs.isneg() && rhs.isneg()))
     {
@@ -550,6 +555,16 @@ constexpr auto operator<(decimal64_fast lhs, decimal64_fast rhs) noexcept -> boo
     {
         return signbit(rhs);
     }
+    #else
+    if (!lhs.isneg() && rhs.isneg())
+    {
+        return false;
+    }
+    else if (lhs.isneg() && !rhs.isneg())
+    {
+        return true;
+    }
+    #endif
 
     return less_parts_impl(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
                            rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
@@ -566,20 +581,24 @@ template <typename Integer>
 constexpr auto operator<(Integer lhs, decimal64_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !less_impl(rhs, lhs) && lhs != rhs;
 }
 
 constexpr auto operator<=(decimal64_fast lhs, decimal64_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -588,10 +607,12 @@ template <typename Integer>
 constexpr auto operator<=(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -600,10 +621,12 @@ template <typename Integer>
 constexpr auto operator<=(Integer lhs, decimal64_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(rhs < lhs);
 }
@@ -629,10 +652,12 @@ constexpr auto operator>(Integer lhs, decimal64_fast rhs) noexcept
 
 constexpr auto operator>=(decimal64_fast lhs, decimal64_fast rhs) noexcept -> bool
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -641,10 +666,12 @@ template <typename Integer>
 constexpr auto operator>=(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -653,10 +680,12 @@ template <typename Integer>
 constexpr auto operator>=(Integer lhs, decimal64_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, bool)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(rhs))
     {
         return false;
     }
+    #endif
 
     return !(lhs < rhs);
 }
@@ -853,6 +882,7 @@ constexpr decimal64_fast::operator Decimal() const noexcept
 
 constexpr auto operator+(decimal64_fast lhs, decimal64_fast rhs) noexcept -> decimal64_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64_fast zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -860,6 +890,7 @@ constexpr auto operator+(decimal64_fast lhs, decimal64_fast rhs) noexcept -> dec
     {
         return res;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && rhs.isneg())
@@ -898,10 +929,12 @@ template <typename Integer>
 constexpr auto operator+(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     bool lhs_bigger {lhs > rhs};
     if (lhs.isneg() && (rhs < 0))
@@ -960,6 +993,7 @@ constexpr auto operator+(Integer lhs, decimal64_fast rhs) noexcept
 
 constexpr auto operator-(decimal64_fast lhs, decimal64_fast rhs) noexcept -> decimal64_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64_fast zero {0, 0};
 
     const auto res {detail::check_non_finite(lhs, rhs)};
@@ -967,6 +1001,7 @@ constexpr auto operator-(decimal64_fast lhs, decimal64_fast rhs) noexcept -> dec
     {
         return res;
     }
+    #endif
 
     if (!lhs.isneg() && rhs.isneg())
     {
@@ -996,10 +1031,12 @@ template <typename Integer>
 constexpr auto operator-(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(lhs) || isnan(lhs))
     {
         return lhs;
     }
+    #endif
 
     if (!lhs.isneg() && (rhs < 0))
     {
@@ -1031,10 +1068,12 @@ template <typename Integer>
 constexpr auto operator-(Integer lhs, decimal64_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isinf(rhs) || isnan(rhs))
     {
         return rhs;
     }
+    #endif
 
     if (lhs >= 0 && rhs.isneg())
     {
@@ -1064,6 +1103,7 @@ constexpr auto operator-(Integer lhs, decimal64_fast rhs) noexcept
 
 constexpr auto operator*(decimal64_fast lhs, decimal64_fast rhs) noexcept -> decimal64_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64_fast zero {0, 0};
 
     const auto non_finite {detail::check_non_finite(lhs, rhs)};
@@ -1071,6 +1111,7 @@ constexpr auto operator*(decimal64_fast lhs, decimal64_fast rhs) noexcept -> dec
     {
         return non_finite;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1090,10 +1131,12 @@ template <typename Integer>
 constexpr auto operator*(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     if (isnan(lhs) || isinf(lhs))
     {
         return lhs;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1123,6 +1166,7 @@ constexpr auto operator*(Integer lhs, decimal64_fast rhs) noexcept
 
 constexpr auto d64_fast_div_impl(decimal64_fast lhs, decimal64_fast rhs, decimal64_fast& q, decimal64_fast& r) noexcept -> void
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64_fast zero {0, 0};
     constexpr decimal64_fast nan {boost::decimal::direct_init_d64(boost::decimal::detail::d64_fast_snan, 0, false)};
@@ -1167,6 +1211,9 @@ constexpr auto d64_fast_div_impl(decimal64_fast lhs, decimal64_fast rhs, decimal
         default:
             static_cast<void>(rhs);
     }
+    #else
+    static_cast<void>(r);
+    #endif
 
     auto sig_lhs {lhs.full_significand()};
     auto exp_lhs {lhs.biased_exponent()};
@@ -1215,6 +1262,7 @@ template <typename Integer>
 constexpr auto operator/(decimal64_fast lhs, Integer rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64_fast zero {0, 0};
     constexpr decimal64_fast nan {boost::decimal::direct_init_d64(boost::decimal::detail::d64_fast_snan, 0, false)};
@@ -1240,6 +1288,7 @@ constexpr auto operator/(decimal64_fast lhs, Integer rhs) noexcept
     {
         return sign ? -inf : inf;
     }
+    #endif
 
     auto lhs_sig {lhs.full_significand()};
     auto lhs_exp {lhs.biased_exponent()};
@@ -1261,6 +1310,7 @@ template <typename Integer>
 constexpr auto operator/(Integer lhs, decimal64_fast rhs) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, Integer, decimal64_fast)
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     // Check pre-conditions
     constexpr decimal64_fast zero {0, 0};
     constexpr decimal64_fast nan {boost::decimal::direct_init_d64(boost::decimal::detail::d64_fast_snan, 0, false)};
@@ -1284,6 +1334,7 @@ constexpr auto operator/(Integer lhs, decimal64_fast rhs) noexcept
         default:
             static_cast<void>(lhs);
     }
+    #endif
 
     auto rhs_sig {rhs.full_significand()};
     auto rhs_exp {rhs.biased_exponent()};
@@ -1390,12 +1441,14 @@ constexpr auto decimal64_fast::operator--(int) noexcept -> decimal64_fast&
 
 constexpr auto scalblnd64f(decimal64_fast num, long exp) noexcept -> decimal64_fast
 {
+    #ifndef BOOST_DECIMAL_FAST_MATH
     constexpr decimal64_fast zero {0, 0};
 
     if (num == zero || exp == 0 || isinf(num) || isnan(num))
     {
         return num;
     }
+    #endif
 
     num = decimal64_fast(num.significand_, num.biased_exponent() + exp, num.sign_);
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -101,6 +101,7 @@ run test_erf.cpp ;
 run test_exp.cpp ;
 compile-fail test_explicit_floats.cpp ;
 run test_expm1.cpp ;
+run test_fast_math.cpp ;
 run test_fenv.cpp ;
 run test_fixed_width_trunc.cpp ;
 run test_float_conversion.cpp ;

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -140,12 +140,41 @@ void random_division()
     }
 }
 
+template <typename T>
+void test_comparisions()
+{
+    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const T dec1 {val1};
+        const T dec2 {val2};
+
+        BOOST_TEST_EQ(val1 == val2, dec1 == dec2);
+        BOOST_TEST_EQ(val1 != val2, dec1 != dec2);
+        BOOST_TEST_EQ(val1 < val2, dec1 < dec2);
+        BOOST_TEST_EQ(val1 <= val2, dec1 <= dec2);
+        BOOST_TEST_EQ(val1 > val2, dec1 > dec2);
+        BOOST_TEST_EQ(val1 >= val2, dec1 >= dec2);
+    }
+}
+
 int main()
 {
     random_addition<decimal32>();
     random_subtraction<decimal32>();
     random_multiplication<decimal32>();
     random_division<decimal32>();
+    test_comparisions<decimal32>();
+
+    random_addition<decimal32_fast>();
+    random_subtraction<decimal32_fast>();
+    random_multiplication<decimal32_fast>();
+    random_division<decimal32_fast>();
+    test_comparisions<decimal32_fast>();
 
     return boost::report_errors();
 }

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -182,5 +182,11 @@ int main()
     random_division<decimal64>();
     test_comparisions<decimal64>();
 
+    random_addition<decimal64_fast>();
+    random_subtraction<decimal64_fast>();
+    random_multiplication<decimal64_fast>();
+    random_division<decimal64_fast>();
+    test_comparisions<decimal64_fast>();
+
     return boost::report_errors();
 }

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -23,7 +23,7 @@ static std::mt19937_64 rng(42); // NOSONAR : Global rng is not const
 template <typename T>
 void random_addition()
 {
-    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+    std::uniform_int_distribution<std::int64_t> dist(1, 1000);
 
     for (std::size_t i {}; i < N; ++i)
     {
@@ -53,7 +53,7 @@ void random_addition()
 template <typename T>
 void random_subtraction()
 {
-    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+    std::uniform_int_distribution<std::int64_t> dist(1, 1000);
 
     for (std::size_t i {}; i < N; ++i)
     {
@@ -83,7 +83,7 @@ void random_subtraction()
 template <typename T>
 void random_multiplication()
 {
-    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+    std::uniform_int_distribution<std::int64_t> dist(1, 1000);
 
     for (std::size_t i {}; i < N; ++i)
     {
@@ -113,7 +113,7 @@ void random_multiplication()
 template <typename T>
 void random_division()
 {
-    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+    std::uniform_int_distribution<std::int64_t> dist(1, 1000);
 
     for (std::size_t i {}; i < N; ++i)
     {

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -1,0 +1,151 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#define BOOST_DECIMAL_FAST_MATH
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <random>
+#include <cstdint>
+
+using namespace boost::decimal;
+
+#if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
+static constexpr auto N = static_cast<std::size_t>(1024U); // Number of trials
+#else
+static constexpr auto N = static_cast<std::size_t>(1024U >> 4U); // Number of trials
+#endif
+
+// NOLINTNEXTLINE : Seed with a constant for repeatability
+static std::mt19937_64 rng(42); // NOSONAR : Global rng is not const
+
+template <typename T>
+void random_addition()
+{
+    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const T dec1 {val1};
+        const T dec2 {val2};
+
+        const T res = dec1 + dec2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 + val2))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 + val2 << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+}
+
+template <typename T>
+void random_subtraction()
+{
+    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const T dec1 {val1};
+        const T dec2 {val2};
+
+        const T res = dec1 - dec2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 - val2))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 + val2 << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+}
+
+template <typename T>
+void random_multiplication()
+{
+    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const T dec1 {val1};
+        const T dec2 {val2};
+
+        const T res = dec1 * dec2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 * val2))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 + val2 << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+}
+
+template <typename T>
+void random_division()
+{
+    std::uniform_int_distribution<std::int64_t> dist(-1000, 1000);
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const T val1 {dist(rng)};
+        const T val2 {dist(rng)};
+
+        const T dec1 {val1};
+        const T dec2 {val2};
+
+        const T res = dec1 / dec2;
+        const auto res_int = static_cast<T>(res);
+
+        if (!BOOST_TEST_EQ(res_int, val1 / val2))
+        {
+            // LCOV_EXCL_START
+            std::cerr << "Val 1: " << val1
+                      << "\nDec 1: " << dec1
+                      << "\nVal 2: " << val2
+                      << "\nDec 2: " << dec2
+                      << "\nDec res: " << res
+                      << "\nInt res: " << val1 + val2 << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    }
+}
+
+int main()
+{
+    random_addition<decimal32>();
+    random_subtraction<decimal32>();
+    random_multiplication<decimal32>();
+    random_division<decimal32>();
+
+    return boost::report_errors();
+}

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -188,5 +188,13 @@ int main()
     random_division<decimal64_fast>();
     test_comparisions<decimal64_fast>();
 
+    #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH)
+    random_addition<decimal128>();
+    random_subtraction<decimal128>();
+    random_multiplication<decimal128>();
+    random_division<decimal128>();
+    test_comparisions<decimal128>();
+    #endif
+
     return boost::report_errors();
 }

--- a/test/test_fast_math.cpp
+++ b/test/test_fast_math.cpp
@@ -176,5 +176,11 @@ int main()
     random_division<decimal32_fast>();
     test_comparisions<decimal32_fast>();
 
+    random_addition<decimal64>();
+    random_subtraction<decimal64>();
+    random_multiplication<decimal64>();
+    random_division<decimal64>();
+    test_comparisions<decimal64>();
+
     return boost::report_errors();
 }


### PR DESCRIPTION
Closes: #623 

Take an apporach similar to intel where `isnan`, `isinf` return false but go one step further and just completely remove the branches to maximize speedup. We also have no control over what `-ffast-math` does. Benchmarks are up to 20% faster without these checks enabled.