### PR TITLE
Improve digit counting methods

### DIFF
--- a/include/boost/decimal/detail/emulated128.hpp
+++ b/include/boost/decimal/detail/emulated128.hpp
@@ -680,12 +680,7 @@ constexpr auto operator!=(uint128 lhs, uint128 rhs) noexcept -> bool
 
 constexpr auto operator<(uint128 lhs, uint128 rhs) noexcept -> bool
 {
-    if (lhs.high == rhs.high)
-    {
-        return lhs.low < rhs.low;
-    }
-
-    return lhs.high < rhs.high;
+    return lhs.high == rhs.high ? lhs.low < rhs.low : lhs.high < rhs.high;
 }
 
 constexpr auto operator<=(uint128 lhs, uint128 rhs) noexcept -> bool

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -307,109 +307,30 @@ constexpr int num_digits(const uint256_t& x) noexcept
 
 #ifdef BOOST_DECIMAL_HAS_INT128
 
-#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
-
-constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
-{
-    constexpr auto big_powers_of_10 = generate_array<boost::decimal::detail::uint128_t, 39>();
-
-    if (x == 0)
-    {
-        return 1;
-    }
-
-    std::uint32_t left = 0U;
-    std::uint32_t right = 38U;
-
-    while (left < right)
-    {
-        std::uint32_t mid = (left + right + 1U) / 2U;
-
-        if (x >= big_powers_of_10[mid])
-        {
-            left = mid;
-        }
-        else
-        {
-            right = mid - 1;
-        }
-    }
-
-    return static_cast<int>(left + 1);
-}
-
-#else
+static constexpr std::uint_fast8_t guess[] = {
+        0 ,0 ,0 ,0 , 1 ,1 ,1 , 2 ,2 ,2 ,
+        3 ,3 ,3 ,3 , 4 ,4 ,4 , 5 ,5 ,5 ,
+        6 ,6 ,6 ,6 , 7 ,7 ,7 , 8 ,8 ,8 ,
+        9 ,9 ,9 ,9 , 10,10,10, 11,11,11,
+        12,12,12,12, 13,13,13, 14,14,14,
+        15,15,15,15, 16,16,16, 17,17,17,
+        18,18,18,18, 19
+};
 
 // Assume that if someone is using 128 bit ints they are favoring the top end of the range
 // Max value is 340,282,366,920,938,463,463,374,607,431,768,211,455 (39 digits)
 constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
 {
-    // There is no literal for boost::decimal::detail::uint128_t, so we need to calculate them using the max value of the
-    // std::uint64_t powers of 10
-    constexpr boost::decimal::detail::uint128_t digits_39 = static_cast<boost::decimal::detail::uint128_t>(UINT64_C(10000000000000000000)) * 
-                                              static_cast<boost::decimal::detail::uint128_t>(UINT64_C(10000000000000000000));
+    const auto high = static_cast<std::uint64_t>(x >> 64);
 
-    constexpr boost::decimal::detail::uint128_t digits_38 = digits_39 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_37 = digits_38 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_36 = digits_37 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_35 = digits_36 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_34 = digits_35 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_33 = digits_34 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_32 = digits_33 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_31 = digits_32 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_30 = digits_31 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_29 = digits_30 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_28 = digits_29 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_27 = digits_28 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_26 = digits_27 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_25 = digits_26 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_24 = digits_25 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_23 = digits_24 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_22 = digits_23 / 10;
-    constexpr boost::decimal::detail::uint128_t digits_21 = digits_22 / 10;
+    if (high != 0)
+    {
+        const auto digits {guess[64 - countl_zero(high)]};
+        return 19 + digits + (x >= impl::powers_of_10[digits]);
+    }
 
-    return (x >= digits_39) ? 39 :
-           (x >= digits_38) ? 38 :
-           (x >= digits_37) ? 37 :
-           (x >= digits_36) ? 36 :
-           (x >= digits_35) ? 35 :
-           (x >= digits_34) ? 34 :
-           (x >= digits_33) ? 33 :
-           (x >= digits_32) ? 32 :
-           (x >= digits_31) ? 31 :
-           (x >= digits_30) ? 30 :
-           (x >= digits_29) ? 29 :
-           (x >= digits_28) ? 28 :
-           (x >= digits_27) ? 27 :
-           (x >= digits_26) ? 26 :
-           (x >= digits_25) ? 25 :
-           (x >= digits_24) ? 24 :
-           (x >= digits_23) ? 23 :
-           (x >= digits_22) ? 22 :
-           (x >= digits_21) ? 21 :
-           (x >= impl::powers_of_10[19]) ? 20 :
-           (x >= impl::powers_of_10[18]) ? 19 :
-           (x >= impl::powers_of_10[17]) ? 18 :
-           (x >= impl::powers_of_10[16]) ? 17 :
-           (x >= impl::powers_of_10[15]) ? 16 :
-           (x >= impl::powers_of_10[14]) ? 15 :
-           (x >= impl::powers_of_10[13]) ? 14 :
-           (x >= impl::powers_of_10[12]) ? 13 :
-           (x >= impl::powers_of_10[11]) ? 12 :
-           (x >= impl::powers_of_10[10]) ? 11 :
-           (x >= impl::powers_of_10[9])  ? 10 :
-           (x >= impl::powers_of_10[8])  ?  9 :
-           (x >= impl::powers_of_10[7])  ?  8 :
-           (x >= impl::powers_of_10[6])  ?  7 :
-           (x >= impl::powers_of_10[5])  ?  6 :
-           (x >= impl::powers_of_10[4])  ?  5 :
-           (x >= impl::powers_of_10[3])  ?  4 :
-           (x >= impl::powers_of_10[2])  ?  3 :
-           (x >= impl::powers_of_10[1])  ?  2 :
-           (x >= impl::powers_of_10[0])  ?  1 : 0;
+    return num_digits(static_cast<std::uint64_t>(x));
 }
-
-#endif // constexpr arrays
 
 #endif // Has int128
 

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -250,106 +250,114 @@ constexpr int num_digits(const uint256_t& x) noexcept
 # pragma warning(pop)
 #endif
 
-static constexpr std::uint_fast8_t guess[] = {
-    0 ,0 ,0 ,0 , 1 ,1 ,1 , 2 ,2 ,2 ,
-    3 ,3 ,3 ,3 , 4 ,4 ,4 , 5 ,5 ,5 ,
-    6 ,6 ,6 ,6 , 7 ,7 ,7 , 8 ,8 ,8 ,
-    9 ,9 ,9 ,9 , 10,10,10, 11,11,11,
-    12,12,12,12, 13,13,13, 14,14,14,
-    15,15,15,15, 16,16,16, 17,17,17,
-    18,18,18,18, 19
-};
-
 #ifdef BOOST_DECIMAL_HAS_INT128
 
 // Assume that if someone is using 128 bit ints they are favoring the top end of the range
 // Max value is 340,282,366,920,938,463,463,374,607,431,768,211,455 (39 digits)
-constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
+constexpr auto num_digits(const boost::decimal::detail::uint128_t& x) noexcept -> int
 {
     using impl::builtin_128_pow10;
 
-    if (x >= builtin_128_pow10[20]) {
-        if (x >= builtin_128_pow10[30]) {
-            if (x >= builtin_128_pow10[35]) {
-                if (x >= builtin_128_pow10[38]) {
-                    if (x >= builtin_128_pow10[39]) return 40;
-                    return 39;
-                } else {
-                    if (x >= builtin_128_pow10[37]) return 38;
-                    if (x >= builtin_128_pow10[36]) return 37;
-                    return 36;
+    if (static_cast<std::uint64_t>(x << 64) == UINT64_C(0))
+    {
+        return num_digits(static_cast<std::uint64_t>(x));
+    }
+
+    if (x >= builtin_128_pow10[30])
+    {
+        if (x >= builtin_128_pow10[35])
+        {
+            if (x >= builtin_128_pow10[38])
+            {
+                if (x >= builtin_128_pow10[39])
+                {
+                    return 40;
                 }
-            } else {
-                if (x >= builtin_128_pow10[33]) {
-                    if (x >= builtin_128_pow10[34]) return 35;
-                    return 34;
-                } else {
-                    if (x >= builtin_128_pow10[31]) return 32;
-                    if (x >= builtin_128_pow10[32]) return 33;
-                    return 31;
-                }
+                return 39;
             }
-        } else {
-            if (x >= builtin_128_pow10[25]) {
-                if (x >= builtin_128_pow10[28]) {
-                    if (x >= builtin_128_pow10[29]) return 30;
-                    return 29;
-                } else {
-                    if (x >= builtin_128_pow10[27]) return 28;
-                    if (x >= builtin_128_pow10[26]) return 27;
-                    return 26;
+            else
+            {
+                if (x >= builtin_128_pow10[37])
+                {
+                    return 38;
                 }
-            } else {
-                if (x >= builtin_128_pow10[23]) {
-                    if (x >= builtin_128_pow10[24]) return 25;
-                    return 24;
-                } else {
-                    if (x >= builtin_128_pow10[22]) return 23;
-                    if (x >= builtin_128_pow10[21]) return 22;
-                    return 21;
+                if (x >= builtin_128_pow10[36])
+                {
+                    return 37;
                 }
+                return 36;
             }
         }
-    } else {
-        if (x >= builtin_128_pow10[10]) {
-            if (x >= builtin_128_pow10[15]) {
-                if (x >= builtin_128_pow10[18]) {
-                    if (x >= builtin_128_pow10[19]) return 20;
-                    return 19;
-                } else {
-                    if (x >= builtin_128_pow10[17]) return 18;
-                    if (x >= builtin_128_pow10[16]) return 17;
-                    return 16;
+        else
+        {
+            if (x >= builtin_128_pow10[33])
+            {
+                if (x >= builtin_128_pow10[34])
+                {
+                    return 35;
                 }
-            } else {
-                if (x >= builtin_128_pow10[13]) {
-                    if (x >= builtin_128_pow10[14]) return 15;
-                    return 14;
-                } else {
-                    if (x >= builtin_128_pow10[12]) return 13;
-                    if (x >= builtin_128_pow10[11]) return 12;
-                    return 11;
-                }
+                return 34;
             }
-        } else {
-            if (x >= builtin_128_pow10[5]) {
-                if (x >= builtin_128_pow10[8]) {
-                    if (x >= builtin_128_pow10[9]) return 10;
-                    return 9;
-                } else {
-                    if (x >= builtin_128_pow10[7]) return 8;
-                    if (x >= builtin_128_pow10[6]) return 7;
-                    return 6;
+            else
+            {
+                if (x >= builtin_128_pow10[31])
+                {
+                    return 32;
                 }
-            } else {
-                if (x >= builtin_128_pow10[3]) {
-                    if (x >= builtin_128_pow10[4]) return 5;
-                    return 4;
-                } else {
-                    if (x >= builtin_128_pow10[2]) return 3;
-                    if (x >= builtin_128_pow10[1]) return 2;
-                    return 1;
+                if (x >= builtin_128_pow10[32])
+                {
+                    return 33;
                 }
+                return 31;
+            }
+        }
+    }
+    else
+    {
+        if (x >= builtin_128_pow10[25])
+        {
+            if (x >= builtin_128_pow10[28])
+            {
+                if (x >= builtin_128_pow10[29])
+                {
+                    return 30;
+                }
+                return 29;
+            }
+            else
+            {
+                if (x >= builtin_128_pow10[27])
+                {
+                    return 28;
+                }
+                if (x >= builtin_128_pow10[26])
+                {
+                    return 27;
+                }
+                return 26;
+            }
+        }
+        else
+        {
+            if (x >= builtin_128_pow10[23])
+            {
+                if (x >= builtin_128_pow10[24])
+                {
+                    return 25;
+                }
+                return 24;
+            }
+            else
+            {
+                if (x >= builtin_128_pow10[22])
+                {
+                    return 23;
+                }
+                if (x >= builtin_128_pow10[21])
+                {
+                    return 22;
+                }
+                return 21;
             }
         }
     }
@@ -363,50 +371,108 @@ constexpr auto num_digits(const uint128& x) noexcept -> int
 {
     using impl::emulated_128_pow10;
 
-    if (x >= emulated_128_pow10[20]) {
-        if (x >= emulated_128_pow10[30]) {
-            if (x >= emulated_128_pow10[35]) {
-                if (x >= emulated_128_pow10[38]) {
-                    if (x >= emulated_128_pow10[39]) return 40;
-                    return 39;
-                } else {
-                    if (x >= emulated_128_pow10[37]) return 38;
-                    if (x >= emulated_128_pow10[36]) return 37;
-                    return 36;
+    if (x.high == 0)
+    {
+        return num_digits(x.low);
+    }
+
+    if (x >= emulated_128_pow10[30])
+    {
+        if (x >= emulated_128_pow10[35])
+        {
+            if (x >= emulated_128_pow10[38])
+            {
+                if (x >= emulated_128_pow10[39])
+                {
+                    return 40;
                 }
-            } else {
-                if (x >= emulated_128_pow10[33]) {
-                    if (x >= emulated_128_pow10[34]) return 35;
-                    return 34;
-                } else {
-                    if (x >= emulated_128_pow10[31]) return 32;
-                    if (x >= emulated_128_pow10[32]) return 33;
-                    return 31;
-                }
+                return 39;
             }
-        } else {
-            if (x >= emulated_128_pow10[25]) {
-                if (x >= emulated_128_pow10[28]) {
-                    if (x >= emulated_128_pow10[29]) return 30;
-                    return 29;
-                } else {
-                    if (x >= emulated_128_pow10[27]) return 28;
-                    if (x >= emulated_128_pow10[26]) return 27;
-                    return 26;
+            else
+            {
+                if (x >= emulated_128_pow10[37])
+                {
+                    return 38;
                 }
-            } else {
-                if (x >= emulated_128_pow10[23]) {
-                    if (x >= emulated_128_pow10[24]) return 25;
-                    return 24;
-                } else {
-                    if (x >= emulated_128_pow10[22]) return 23;
-                    if (x >= emulated_128_pow10[21]) return 22;
-                    return 21;
+                if (x >= emulated_128_pow10[36])
+                {
+                    return 37;
                 }
+                return 36;
             }
         }
-    } else {
-        return num_digits(x.low);
+        else
+        {
+            if (x >= emulated_128_pow10[33])
+            {
+                if (x >= emulated_128_pow10[34])
+                {
+                    return 35;
+                }
+                return 34;
+            }
+            else
+            {
+                if (x >= emulated_128_pow10[31])
+                {
+                    return 32;
+                }
+                if (x >= emulated_128_pow10[32])
+                {
+                    return 33;
+                }
+                return 31;
+            }
+        }
+    }
+    else
+    {
+        if (x >= emulated_128_pow10[25])
+        {
+            if (x >= emulated_128_pow10[28])
+            {
+                if (x >= emulated_128_pow10[29])
+                {
+                    return 30;
+                }
+                return 29;
+            }
+            else
+            {
+                if (x >= emulated_128_pow10[27])
+                {
+                    return 28;
+                }
+                if (x >= emulated_128_pow10[26])
+                {
+                    return 27;
+                }
+                return 26;
+            }
+        }
+        else
+        {
+            if (x >= emulated_128_pow10[23])
+            {
+                if (x >= emulated_128_pow10[24])
+                {
+                    return 25;
+                }
+                return 24;
+            }
+            else
+            {
+                if (x >= emulated_128_pow10[22])
+                {
+                    return 23;
+                }
+                if (x >= emulated_128_pow10[21])
+                {
+                    return 22;
+                }
+                return 21;
+            }
+        }
     }
 
     return 0;

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -493,47 +493,7 @@ constexpr auto num_digits(const uint128& x) noexcept -> int
             }
         }
     } else {
-        if (x >= emulated_128_pow10[10]) {
-            if (x >= emulated_128_pow10[15]) {
-                if (x >= emulated_128_pow10[18]) {
-                    if (x >= emulated_128_pow10[19]) return 20;
-                    return 19;
-                } else {
-                    if (x >= emulated_128_pow10[17]) return 18;
-                    if (x >= emulated_128_pow10[16]) return 17;
-                    return 16;
-                }
-            } else {
-                if (x >= emulated_128_pow10[13]) {
-                    if (x >= emulated_128_pow10[14]) return 15;
-                    return 14;
-                } else {
-                    if (x >= emulated_128_pow10[12]) return 13;
-                    if (x >= emulated_128_pow10[11]) return 12;
-                    return 11;
-                }
-            }
-        } else {
-            if (x >= emulated_128_pow10[5]) {
-                if (x >= emulated_128_pow10[8]) {
-                    if (x >= emulated_128_pow10[9]) return 10;
-                    return 9;
-                } else {
-                    if (x >= emulated_128_pow10[7]) return 8;
-                    if (x >= emulated_128_pow10[6]) return 7;
-                    return 6;
-                }
-            } else {
-                if (x >= emulated_128_pow10[3]) {
-                    if (x >= emulated_128_pow10[4]) return 5;
-                    return 4;
-                } else {
-                    if (x >= emulated_128_pow10[2]) return 3;
-                    if (x >= emulated_128_pow10[1]) return 2;
-                    return 1;
-                }
-            }
-        }
+        return num_digits(x.low);
     }
 
     return 0;

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -182,61 +182,6 @@ constexpr auto generate_array() noexcept -> std::array<T, N>
     return values;
 }
 
-constexpr int num_digits(uint128 x) noexcept
-{
-    constexpr auto big_powers_of_10 = generate_array<boost::decimal::detail::uint128, 39>();
-
-    if (x == 0)
-    {
-        return 1;
-    }
-
-    std::uint32_t left = 0U;
-    std::uint32_t right = 38U;
-
-    while (left < right)
-    {
-        std::uint32_t mid = (left + right + 1U) / 2U;
-
-        if (x >= big_powers_of_10[mid])
-        {
-            left = mid;
-        }
-        else
-        {
-            right = mid - 1;
-        }
-    }
-
-    return static_cast<int>(left + 1);
-}
-
-#else
-
-constexpr int num_digits(uint128 x) noexcept
-{
-    if (x.high == 0)
-    {
-        return num_digits(x.low);
-    }
-
-    constexpr uint128 digits_39 = static_cast<uint128>(UINT64_C(10000000000000000000)) *
-                                  static_cast<uint128>(UINT64_C(10000000000000000000));
-    uint128 current_power_of_10 = digits_39;
-
-    for (int i = 39; i > 0; --i)
-    {
-        if (x >= current_power_of_10)
-        {
-            return i;
-        }
-
-        current_power_of_10 /= 10U;
-    }
-
-    return 1;
-}
-
 #endif // Constexpr array
 
 #if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
@@ -305,17 +250,17 @@ constexpr int num_digits(const uint256_t& x) noexcept
 # pragma warning(pop)
 #endif
 
-#ifdef BOOST_DECIMAL_HAS_INT128
-
 static constexpr std::uint_fast8_t guess[] = {
-        0 ,0 ,0 ,0 , 1 ,1 ,1 , 2 ,2 ,2 ,
-        3 ,3 ,3 ,3 , 4 ,4 ,4 , 5 ,5 ,5 ,
-        6 ,6 ,6 ,6 , 7 ,7 ,7 , 8 ,8 ,8 ,
-        9 ,9 ,9 ,9 , 10,10,10, 11,11,11,
-        12,12,12,12, 13,13,13, 14,14,14,
-        15,15,15,15, 16,16,16, 17,17,17,
-        18,18,18,18, 19
+    0 ,0 ,0 ,0 , 1 ,1 ,1 , 2 ,2 ,2 ,
+    3 ,3 ,3 ,3 , 4 ,4 ,4 , 5 ,5 ,5 ,
+    6 ,6 ,6 ,6 , 7 ,7 ,7 , 8 ,8 ,8 ,
+    9 ,9 ,9 ,9 , 10,10,10, 11,11,11,
+    12,12,12,12, 13,13,13, 14,14,14,
+    15,15,15,15, 16,16,16, 17,17,17,
+    18,18,18,18, 19
 };
+
+#ifdef BOOST_DECIMAL_HAS_INT128
 
 // Assume that if someone is using 128 bit ints they are favoring the top end of the range
 // Max value is 340,282,366,920,938,463,463,374,607,431,768,211,455 (39 digits)
@@ -333,6 +278,76 @@ constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
 }
 
 #endif // Has int128
+
+static constexpr uint128 correction_powers_of_10[] =
+{
+        uint128 {UINT64_C(0), UINT64_C(1)},
+        uint128 {UINT64_C(0), UINT64_C(10)},
+        uint128 {UINT64_C(0), UINT64_C(100)},
+        uint128 {UINT64_C(0), UINT64_C(1000)},
+        uint128 {UINT64_C(0), UINT64_C(10000)},
+        uint128 {UINT64_C(0), UINT64_C(100000)},
+        uint128 {UINT64_C(0), UINT64_C(1000000)},
+        uint128 {UINT64_C(0), UINT64_C(10000000)},
+        uint128 {UINT64_C(0), UINT64_C(100000000)},
+        uint128 {UINT64_C(0), UINT64_C(1000000000)},
+        uint128 {UINT64_C(0), UINT64_C(10000000000)},
+        uint128 {UINT64_C(0), UINT64_C(100000000000)},
+        uint128 {UINT64_C(0), UINT64_C(1000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(10000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(100000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(1000000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(10000000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(100000000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(1000000000000000000)},
+        uint128 {UINT64_C(0), UINT64_C(10000000000000000000)},
+        uint128 {UINT64_C(5), UINT64_C(7766279631452241920)},
+        uint128 {UINT64_C(54), UINT64_C(3875820019684212736)},
+        uint128 {UINT64_C(542), UINT64_C(1864712049423024128)},
+        uint128 {UINT64_C(5421), UINT64_C(200376420520689664)},
+        uint128 {UINT64_C(54210), UINT64_C(2003764205206896640)},
+        uint128 {UINT64_C(542101), UINT64_C(1590897978359414784)},
+        uint128 {UINT64_C(5421010), UINT64_C(15908979783594147840)},
+        uint128 {UINT64_C(54210108), UINT64_C(11515845246265065472)},
+        uint128 {UINT64_C(542101086), UINT64_C(4477988020393345024)},
+        uint128 {UINT64_C(5421010862), UINT64_C(7886392056514347008)},
+        uint128 {UINT64_C(54210108624), UINT64_C(5076944270305263616)},
+        uint128 {UINT64_C(542101086242), UINT64_C(13875954555633532928)},
+        uint128 {UINT64_C(5421010862427), UINT64_C(9632337040368467968)},
+        uint128 {UINT64_C(54210108624275), UINT64_C(4089650035136921600)},
+        uint128 {UINT64_C(542101086242752), UINT64_C(4003012203950112768)},
+        uint128 {UINT64_C(5421010862427522), UINT64_C(3136633892082024448)},
+        uint128 {UINT64_C(54210108624275221), UINT64_C(12919594847110692864)},
+        uint128 {UINT64_C(542101086242752217), UINT64_C(68739955140067328)},
+        uint128 {UINT64_C(5421010862427522170), UINT64_C(687399551400673280)},
+        uint128 {UINT64_C(17316620476856118468), UINT64_C(6873995514006732800)},
+};
+
+static_assert(sizeof(correction_powers_of_10) == sizeof(uint128) * 40, "Should have 10^0 to 10^39");
+
+constexpr auto num_digits(const uint128& x) noexcept -> int
+{
+    constexpr auto uint64_t_dig {std::numeric_limits<std::uint64_t>::digits10};
+    constexpr auto uint64_t_bits {64};
+
+    if (x.high != 0)
+    {
+        const auto digits {guess[uint64_t_bits - countl_zero(x.high)]};
+        auto ret_val {uint64_t_dig + digits + (x >= correction_powers_of_10[digits])};
+
+        // We need to make sure that deviations in the number of digits in the low word
+        // (e.g. 18 or 20 decimal digits) are compensated for.
+        if (x > correction_powers_of_10[ret_val])
+        {
+            ret_val++;
+        }
+
+        return ret_val;
+    }
+
+    const auto ret_val {num_digits(x.low)};
+    return ret_val;
+}
 
 } // namespace detail
 } // namespace decimal

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -262,55 +262,12 @@ static constexpr std::uint_fast8_t guess[] = {
 
 #ifdef BOOST_DECIMAL_HAS_INT128
 
-static constexpr uint128_t builtin_128_pow10[] = {
-        uint128_t(1),
-        uint128_t(10),
-        uint128_t(100),
-        uint128_t(1000),
-        uint128_t(10000),
-        uint128_t(100000),
-        uint128_t(1000000),
-        uint128_t(10000000),
-        uint128_t(100000000),
-        uint128_t(1000000000),
-        uint128_t(10000000000),
-        uint128_t(100000000000),
-        uint128_t(1000000000000),
-        uint128_t(10000000000000),
-        uint128_t(100000000000000),
-        uint128_t(1000000000000000),
-        uint128_t(10000000000000000),
-        uint128_t(100000000000000000),
-        uint128_t(1000000000000000000),
-        uint128_t(10000000000000000000ULL),
-        (uint128_t(7766279631452241920ULL) << 64) | uint128_t(5),
-        (uint128_t(3875820019684212736ULL) << 64) | uint128_t(54),
-        (uint128_t(1864712049423024128ULL) << 64) | uint128_t(542),
-        (uint128_t(200376420520689664ULL) << 64) | uint128_t(5421),
-        (uint128_t(2003764205206896640ULL) << 64) | uint128_t(54210),
-        (uint128_t(1590897978359414784ULL) << 64) | uint128_t(542101),
-        (uint128_t(15908979783594147840ULL) << 64) | uint128_t(5421010),
-        (uint128_t(11515845246265065472ULL) << 64) | uint128_t(54210108),
-        (uint128_t(4477988020393345024ULL) << 64) | uint128_t(542101086),
-        (uint128_t(7886392056514347008ULL) << 64) | uint128_t(5421010862),
-        (uint128_t(5076944270305263616ULL) << 64) | uint128_t(54210108624),
-        (uint128_t(13875954555633532928ULL) << 64) | uint128_t(542101086242),
-        (uint128_t(9632337040368467968ULL) << 64) | uint128_t(5421010862427),
-        (uint128_t(4089650035136921600ULL) << 64) | uint128_t(54210108624275),
-        (uint128_t(4003012203950112768ULL) << 64) | uint128_t(542101086242752),
-        (uint128_t(3136633892082024448ULL) << 64) | uint128_t(5421010862427522),
-        (uint128_t(12919594847110692864ULL) << 64) | uint128_t(54210108624275221),
-        (uint128_t(68739955140067328ULL) << 64) | uint128_t(542101086242752217),
-        (uint128_t(687399551400673280ULL) << 64) | uint128_t(5421010862427522170ULL),
-        (uint128_t(6873995514006732800ULL) << 64) | uint128_t(17316620476856118468ULL)
-};
-
-static_assert(sizeof(builtin_128_pow10) == sizeof(boost::decimal::detail::uint128_t) * 40, "Should have 10^0 to 10^39");
-
 // Assume that if someone is using 128 bit ints they are favoring the top end of the range
 // Max value is 340,282,366,920,938,463,463,374,607,431,768,211,455 (39 digits)
 constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
 {
+    using impl::builtin_128_pow10;
+
     if (x >= builtin_128_pow10[20]) {
         if (x >= builtin_128_pow10[30]) {
             if (x >= builtin_128_pow10[35]) {
@@ -402,54 +359,10 @@ constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
 
 #endif // Has int128
 
-static constexpr uint128 emulated_128_pow10[] =
-{
-        uint128 {UINT64_C(0), UINT64_C(1)},
-        uint128 {UINT64_C(0), UINT64_C(10)},
-        uint128 {UINT64_C(0), UINT64_C(100)},
-        uint128 {UINT64_C(0), UINT64_C(1000)},
-        uint128 {UINT64_C(0), UINT64_C(10000)},
-        uint128 {UINT64_C(0), UINT64_C(100000)},
-        uint128 {UINT64_C(0), UINT64_C(1000000)},
-        uint128 {UINT64_C(0), UINT64_C(10000000)},
-        uint128 {UINT64_C(0), UINT64_C(100000000)},
-        uint128 {UINT64_C(0), UINT64_C(1000000000)},
-        uint128 {UINT64_C(0), UINT64_C(10000000000)},
-        uint128 {UINT64_C(0), UINT64_C(100000000000)},
-        uint128 {UINT64_C(0), UINT64_C(1000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(10000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(100000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(1000000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(10000000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(100000000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(1000000000000000000)},
-        uint128 {UINT64_C(0), UINT64_C(10000000000000000000)},
-        uint128 {UINT64_C(5), UINT64_C(7766279631452241920)},
-        uint128 {UINT64_C(54), UINT64_C(3875820019684212736)},
-        uint128 {UINT64_C(542), UINT64_C(1864712049423024128)},
-        uint128 {UINT64_C(5421), UINT64_C(200376420520689664)},
-        uint128 {UINT64_C(54210), UINT64_C(2003764205206896640)},
-        uint128 {UINT64_C(542101), UINT64_C(1590897978359414784)},
-        uint128 {UINT64_C(5421010), UINT64_C(15908979783594147840)},
-        uint128 {UINT64_C(54210108), UINT64_C(11515845246265065472)},
-        uint128 {UINT64_C(542101086), UINT64_C(4477988020393345024)},
-        uint128 {UINT64_C(5421010862), UINT64_C(7886392056514347008)},
-        uint128 {UINT64_C(54210108624), UINT64_C(5076944270305263616)},
-        uint128 {UINT64_C(542101086242), UINT64_C(13875954555633532928)},
-        uint128 {UINT64_C(5421010862427), UINT64_C(9632337040368467968)},
-        uint128 {UINT64_C(54210108624275), UINT64_C(4089650035136921600)},
-        uint128 {UINT64_C(542101086242752), UINT64_C(4003012203950112768)},
-        uint128 {UINT64_C(5421010862427522), UINT64_C(3136633892082024448)},
-        uint128 {UINT64_C(54210108624275221), UINT64_C(12919594847110692864)},
-        uint128 {UINT64_C(542101086242752217), UINT64_C(68739955140067328)},
-        uint128 {UINT64_C(5421010862427522170), UINT64_C(687399551400673280)},
-        uint128 {UINT64_C(17316620476856118468), UINT64_C(6873995514006732800)},
-};
-
-static_assert(sizeof(emulated_128_pow10) == sizeof(uint128) * 40, "Should have 10^0 to 10^39");
-
 constexpr auto num_digits(const uint128& x) noexcept -> int
 {
+    using impl::emulated_128_pow10;
+
     if (x >= emulated_128_pow10[20]) {
         if (x >= emulated_128_pow10[30]) {
             if (x >= emulated_128_pow10[35]) {

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -337,10 +337,7 @@ constexpr auto num_digits(const uint128& x) noexcept -> int
 
         // We need to make sure that deviations in the number of digits in the low word
         // (e.g. 18 or 20 decimal digits) are compensated for.
-        if (x > correction_powers_of_10[ret_val])
-        {
-            ret_val++;
-        }
+        ret_val += static_cast<int>(x > correction_powers_of_10[ret_val]);
 
         return ret_val;
     }

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -262,24 +262,147 @@ static constexpr std::uint_fast8_t guess[] = {
 
 #ifdef BOOST_DECIMAL_HAS_INT128
 
+static constexpr uint128_t builtin_128_pow10[] = {
+        uint128_t(1),
+        uint128_t(10),
+        uint128_t(100),
+        uint128_t(1000),
+        uint128_t(10000),
+        uint128_t(100000),
+        uint128_t(1000000),
+        uint128_t(10000000),
+        uint128_t(100000000),
+        uint128_t(1000000000),
+        uint128_t(10000000000),
+        uint128_t(100000000000),
+        uint128_t(1000000000000),
+        uint128_t(10000000000000),
+        uint128_t(100000000000000),
+        uint128_t(1000000000000000),
+        uint128_t(10000000000000000),
+        uint128_t(100000000000000000),
+        uint128_t(1000000000000000000),
+        uint128_t(10000000000000000000ULL),
+        (uint128_t(7766279631452241920ULL) << 64) | uint128_t(5),
+        (uint128_t(3875820019684212736ULL) << 64) | uint128_t(54),
+        (uint128_t(1864712049423024128ULL) << 64) | uint128_t(542),
+        (uint128_t(200376420520689664ULL) << 64) | uint128_t(5421),
+        (uint128_t(2003764205206896640ULL) << 64) | uint128_t(54210),
+        (uint128_t(1590897978359414784ULL) << 64) | uint128_t(542101),
+        (uint128_t(15908979783594147840ULL) << 64) | uint128_t(5421010),
+        (uint128_t(11515845246265065472ULL) << 64) | uint128_t(54210108),
+        (uint128_t(4477988020393345024ULL) << 64) | uint128_t(542101086),
+        (uint128_t(7886392056514347008ULL) << 64) | uint128_t(5421010862),
+        (uint128_t(5076944270305263616ULL) << 64) | uint128_t(54210108624),
+        (uint128_t(13875954555633532928ULL) << 64) | uint128_t(542101086242),
+        (uint128_t(9632337040368467968ULL) << 64) | uint128_t(5421010862427),
+        (uint128_t(4089650035136921600ULL) << 64) | uint128_t(54210108624275),
+        (uint128_t(4003012203950112768ULL) << 64) | uint128_t(542101086242752),
+        (uint128_t(3136633892082024448ULL) << 64) | uint128_t(5421010862427522),
+        (uint128_t(12919594847110692864ULL) << 64) | uint128_t(54210108624275221),
+        (uint128_t(68739955140067328ULL) << 64) | uint128_t(542101086242752217),
+        (uint128_t(687399551400673280ULL) << 64) | uint128_t(5421010862427522170ULL),
+        (uint128_t(6873995514006732800ULL) << 64) | uint128_t(17316620476856118468ULL)
+};
+
+static_assert(sizeof(builtin_128_pow10) == sizeof(boost::decimal::detail::uint128_t) * 40, "Should have 10^0 to 10^39");
+
 // Assume that if someone is using 128 bit ints they are favoring the top end of the range
 // Max value is 340,282,366,920,938,463,463,374,607,431,768,211,455 (39 digits)
 constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
 {
-    const auto high = static_cast<std::uint64_t>(x >> 64);
-
-    if (high != 0)
-    {
-        const auto digits {guess[64 - countl_zero(high)]};
-        return 19 + digits + (x >= impl::powers_of_10[digits]);
+    if (x >= builtin_128_pow10[20]) {
+        if (x >= builtin_128_pow10[30]) {
+            if (x >= builtin_128_pow10[35]) {
+                if (x >= builtin_128_pow10[38]) {
+                    if (x >= builtin_128_pow10[39]) return 40;
+                    return 39;
+                } else {
+                    if (x >= builtin_128_pow10[37]) return 38;
+                    if (x >= builtin_128_pow10[36]) return 37;
+                    return 36;
+                }
+            } else {
+                if (x >= builtin_128_pow10[33]) {
+                    if (x >= builtin_128_pow10[34]) return 35;
+                    return 34;
+                } else {
+                    if (x >= builtin_128_pow10[31]) return 32;
+                    if (x >= builtin_128_pow10[32]) return 33;
+                    return 31;
+                }
+            }
+        } else {
+            if (x >= builtin_128_pow10[25]) {
+                if (x >= builtin_128_pow10[28]) {
+                    if (x >= builtin_128_pow10[29]) return 30;
+                    return 29;
+                } else {
+                    if (x >= builtin_128_pow10[27]) return 28;
+                    if (x >= builtin_128_pow10[26]) return 27;
+                    return 26;
+                }
+            } else {
+                if (x >= builtin_128_pow10[23]) {
+                    if (x >= builtin_128_pow10[24]) return 25;
+                    return 24;
+                } else {
+                    if (x >= builtin_128_pow10[22]) return 23;
+                    if (x >= builtin_128_pow10[21]) return 22;
+                    return 21;
+                }
+            }
+        }
+    } else {
+        if (x >= builtin_128_pow10[10]) {
+            if (x >= builtin_128_pow10[15]) {
+                if (x >= builtin_128_pow10[18]) {
+                    if (x >= builtin_128_pow10[19]) return 20;
+                    return 19;
+                } else {
+                    if (x >= builtin_128_pow10[17]) return 18;
+                    if (x >= builtin_128_pow10[16]) return 17;
+                    return 16;
+                }
+            } else {
+                if (x >= builtin_128_pow10[13]) {
+                    if (x >= builtin_128_pow10[14]) return 15;
+                    return 14;
+                } else {
+                    if (x >= builtin_128_pow10[12]) return 13;
+                    if (x >= builtin_128_pow10[11]) return 12;
+                    return 11;
+                }
+            }
+        } else {
+            if (x >= builtin_128_pow10[5]) {
+                if (x >= builtin_128_pow10[8]) {
+                    if (x >= builtin_128_pow10[9]) return 10;
+                    return 9;
+                } else {
+                    if (x >= builtin_128_pow10[7]) return 8;
+                    if (x >= builtin_128_pow10[6]) return 7;
+                    return 6;
+                }
+            } else {
+                if (x >= builtin_128_pow10[3]) {
+                    if (x >= builtin_128_pow10[4]) return 5;
+                    return 4;
+                } else {
+                    if (x >= builtin_128_pow10[2]) return 3;
+                    if (x >= builtin_128_pow10[1]) return 2;
+                    return 1;
+                }
+            }
+        }
     }
 
-    return num_digits(static_cast<std::uint64_t>(x));
+    return 0;
 }
 
 #endif // Has int128
 
-static constexpr uint128 correction_powers_of_10[] =
+static constexpr uint128 emulated_128_pow10[] =
 {
         uint128 {UINT64_C(0), UINT64_C(1)},
         uint128 {UINT64_C(0), UINT64_C(10)},
@@ -323,27 +446,97 @@ static constexpr uint128 correction_powers_of_10[] =
         uint128 {UINT64_C(17316620476856118468), UINT64_C(6873995514006732800)},
 };
 
-static_assert(sizeof(correction_powers_of_10) == sizeof(uint128) * 40, "Should have 10^0 to 10^39");
+static_assert(sizeof(emulated_128_pow10) == sizeof(uint128) * 40, "Should have 10^0 to 10^39");
 
 constexpr auto num_digits(const uint128& x) noexcept -> int
 {
-    constexpr auto uint64_t_dig {std::numeric_limits<std::uint64_t>::digits10};
-    constexpr auto uint64_t_bits {64};
-
-    if (x.high != 0)
-    {
-        const auto digits {guess[uint64_t_bits - countl_zero(x.high)]};
-        auto ret_val {uint64_t_dig + digits + (x >= correction_powers_of_10[digits])};
-
-        // We need to make sure that deviations in the number of digits in the low word
-        // (e.g. 18 or 20 decimal digits) are compensated for.
-        ret_val += static_cast<int>(x > correction_powers_of_10[ret_val]);
-
-        return ret_val;
+    if (x >= emulated_128_pow10[20]) {
+        if (x >= emulated_128_pow10[30]) {
+            if (x >= emulated_128_pow10[35]) {
+                if (x >= emulated_128_pow10[38]) {
+                    if (x >= emulated_128_pow10[39]) return 40;
+                    return 39;
+                } else {
+                    if (x >= emulated_128_pow10[37]) return 38;
+                    if (x >= emulated_128_pow10[36]) return 37;
+                    return 36;
+                }
+            } else {
+                if (x >= emulated_128_pow10[33]) {
+                    if (x >= emulated_128_pow10[34]) return 35;
+                    return 34;
+                } else {
+                    if (x >= emulated_128_pow10[31]) return 32;
+                    if (x >= emulated_128_pow10[32]) return 33;
+                    return 31;
+                }
+            }
+        } else {
+            if (x >= emulated_128_pow10[25]) {
+                if (x >= emulated_128_pow10[28]) {
+                    if (x >= emulated_128_pow10[29]) return 30;
+                    return 29;
+                } else {
+                    if (x >= emulated_128_pow10[27]) return 28;
+                    if (x >= emulated_128_pow10[26]) return 27;
+                    return 26;
+                }
+            } else {
+                if (x >= emulated_128_pow10[23]) {
+                    if (x >= emulated_128_pow10[24]) return 25;
+                    return 24;
+                } else {
+                    if (x >= emulated_128_pow10[22]) return 23;
+                    if (x >= emulated_128_pow10[21]) return 22;
+                    return 21;
+                }
+            }
+        }
+    } else {
+        if (x >= emulated_128_pow10[10]) {
+            if (x >= emulated_128_pow10[15]) {
+                if (x >= emulated_128_pow10[18]) {
+                    if (x >= emulated_128_pow10[19]) return 20;
+                    return 19;
+                } else {
+                    if (x >= emulated_128_pow10[17]) return 18;
+                    if (x >= emulated_128_pow10[16]) return 17;
+                    return 16;
+                }
+            } else {
+                if (x >= emulated_128_pow10[13]) {
+                    if (x >= emulated_128_pow10[14]) return 15;
+                    return 14;
+                } else {
+                    if (x >= emulated_128_pow10[12]) return 13;
+                    if (x >= emulated_128_pow10[11]) return 12;
+                    return 11;
+                }
+            }
+        } else {
+            if (x >= emulated_128_pow10[5]) {
+                if (x >= emulated_128_pow10[8]) {
+                    if (x >= emulated_128_pow10[9]) return 10;
+                    return 9;
+                } else {
+                    if (x >= emulated_128_pow10[7]) return 8;
+                    if (x >= emulated_128_pow10[6]) return 7;
+                    return 6;
+                }
+            } else {
+                if (x >= emulated_128_pow10[3]) {
+                    if (x >= emulated_128_pow10[4]) return 5;
+                    return 4;
+                } else {
+                    if (x >= emulated_128_pow10[2]) return 3;
+                    if (x >= emulated_128_pow10[1]) return 2;
+                    return 1;
+                }
+            }
+        }
     }
 
-    const auto ret_val {num_digits(x.low)};
-    return ret_val;
+    return 0;
 }
 
 } // namespace detail

--- a/include/boost/decimal/detail/power_tables.hpp
+++ b/include/boost/decimal/detail/power_tables.hpp
@@ -27,6 +27,101 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t powers_of_10[20] =
     UINT64_C(10000000000000000000)
 };
 
+BOOST_DECIMAL_CONSTEXPR_VARIABLE uint128 emulated_128_pow10[] =
+{
+    uint128 {UINT64_C(0), UINT64_C(1)},
+    uint128 {UINT64_C(0), UINT64_C(10)},
+    uint128 {UINT64_C(0), UINT64_C(100)},
+    uint128 {UINT64_C(0), UINT64_C(1000)},
+    uint128 {UINT64_C(0), UINT64_C(10000)},
+    uint128 {UINT64_C(0), UINT64_C(100000)},
+    uint128 {UINT64_C(0), UINT64_C(1000000)},
+    uint128 {UINT64_C(0), UINT64_C(10000000)},
+    uint128 {UINT64_C(0), UINT64_C(100000000)},
+    uint128 {UINT64_C(0), UINT64_C(1000000000)},
+    uint128 {UINT64_C(0), UINT64_C(10000000000)},
+    uint128 {UINT64_C(0), UINT64_C(100000000000)},
+    uint128 {UINT64_C(0), UINT64_C(1000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(10000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(100000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(1000000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(10000000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(100000000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(1000000000000000000)},
+    uint128 {UINT64_C(0), UINT64_C(10000000000000000000)},
+    uint128 {UINT64_C(5), UINT64_C(7766279631452241920)},
+    uint128 {UINT64_C(54), UINT64_C(3875820019684212736)},
+    uint128 {UINT64_C(542), UINT64_C(1864712049423024128)},
+    uint128 {UINT64_C(5421), UINT64_C(200376420520689664)},
+    uint128 {UINT64_C(54210), UINT64_C(2003764205206896640)},
+    uint128 {UINT64_C(542101), UINT64_C(1590897978359414784)},
+    uint128 {UINT64_C(5421010), UINT64_C(15908979783594147840)},
+    uint128 {UINT64_C(54210108), UINT64_C(11515845246265065472)},
+    uint128 {UINT64_C(542101086), UINT64_C(4477988020393345024)},
+    uint128 {UINT64_C(5421010862), UINT64_C(7886392056514347008)},
+    uint128 {UINT64_C(54210108624), UINT64_C(5076944270305263616)},
+    uint128 {UINT64_C(542101086242), UINT64_C(13875954555633532928)},
+    uint128 {UINT64_C(5421010862427), UINT64_C(9632337040368467968)},
+    uint128 {UINT64_C(54210108624275), UINT64_C(4089650035136921600)},
+    uint128 {UINT64_C(542101086242752), UINT64_C(4003012203950112768)},
+    uint128 {UINT64_C(5421010862427522), UINT64_C(3136633892082024448)},
+    uint128 {UINT64_C(54210108624275221), UINT64_C(12919594847110692864)},
+    uint128 {UINT64_C(542101086242752217), UINT64_C(68739955140067328)},
+    uint128 {UINT64_C(5421010862427522170), UINT64_C(687399551400673280)},
+    uint128 {UINT64_C(17316620476856118468), UINT64_C(6873995514006732800)},
+};
+
+static_assert(sizeof(emulated_128_pow10) == sizeof(uint128) * 40, "Should have 10^0 to 10^39");
+
+#ifdef BOOST_DECIMAL_HAS_INT128
+
+static constexpr uint128_t builtin_128_pow10[] = {
+    uint128_t(1),
+    uint128_t(10),
+    uint128_t(100),
+    uint128_t(1000),
+    uint128_t(10000),
+    uint128_t(100000),
+    uint128_t(1000000),
+    uint128_t(10000000),
+    uint128_t(100000000),
+    uint128_t(1000000000),
+    uint128_t(10000000000),
+    uint128_t(100000000000),
+    uint128_t(1000000000000),
+    uint128_t(10000000000000),
+    uint128_t(100000000000000),
+    uint128_t(1000000000000000),
+    uint128_t(10000000000000000),
+    uint128_t(100000000000000000),
+    uint128_t(1000000000000000000),
+    uint128_t(10000000000000000000ULL),
+    (uint128_t(7766279631452241920ULL) << 64) | uint128_t(5),
+    (uint128_t(3875820019684212736ULL) << 64) | uint128_t(54),
+    (uint128_t(1864712049423024128ULL) << 64) | uint128_t(542),
+    (uint128_t(200376420520689664ULL) << 64) | uint128_t(5421),
+    (uint128_t(2003764205206896640ULL) << 64) | uint128_t(54210),
+    (uint128_t(1590897978359414784ULL) << 64) | uint128_t(542101),
+    (uint128_t(15908979783594147840ULL) << 64) | uint128_t(5421010),
+    (uint128_t(11515845246265065472ULL) << 64) | uint128_t(54210108),
+    (uint128_t(4477988020393345024ULL) << 64) | uint128_t(542101086),
+    (uint128_t(7886392056514347008ULL) << 64) | uint128_t(5421010862),
+    (uint128_t(5076944270305263616ULL) << 64) | uint128_t(54210108624),
+    (uint128_t(13875954555633532928ULL) << 64) | uint128_t(542101086242),
+    (uint128_t(9632337040368467968ULL) << 64) | uint128_t(5421010862427),
+    (uint128_t(4089650035136921600ULL) << 64) | uint128_t(54210108624275),
+    (uint128_t(4003012203950112768ULL) << 64) | uint128_t(542101086242752),
+    (uint128_t(3136633892082024448ULL) << 64) | uint128_t(5421010862427522),
+    (uint128_t(12919594847110692864ULL) << 64) | uint128_t(54210108624275221),
+    (uint128_t(68739955140067328ULL) << 64) | uint128_t(542101086242752217),
+    (uint128_t(687399551400673280ULL) << 64) | uint128_t(5421010862427522170ULL),
+    (uint128_t(6873995514006732800ULL) << 64) | uint128_t(17316620476856118468ULL)
+};
+
+static_assert(sizeof(builtin_128_pow10) == sizeof(boost::decimal::detail::uint128_t) * 40, "Should have 10^0 to 10^39");
+
+#endif
+
 } // namespace impl
 
 template <typename T>
@@ -43,18 +138,7 @@ constexpr auto pow10(T n) noexcept -> T
 template <>
 constexpr auto pow10(detail::uint128 n) noexcept -> detail::uint128
 {
-    detail::uint128 res {1};
-    if (n <= 19)
-    {
-        res = impl::powers_of_10[static_cast<std::size_t>(n)];
-    }
-    else
-    {
-        res = impl::powers_of_10[static_cast<std::size_t>(19)];
-        res *= impl::powers_of_10[static_cast<std::size_t>(n - 19)];
-    }
-
-    return res;
+    return impl::emulated_128_pow10[static_cast<std::size_t>(n.low)];
 }
 
 #ifdef BOOST_DECIMAL_HAS_INT128
@@ -62,18 +146,7 @@ constexpr auto pow10(detail::uint128 n) noexcept -> detail::uint128
 template <>
 constexpr auto pow10(detail::uint128_t n) noexcept -> detail::uint128_t
 {
-    detail::uint128_t res {1};
-    if (n <= 19)
-    {
-        res = impl::powers_of_10[static_cast<std::size_t>(n)];
-    }
-    else
-    {
-        res = impl::powers_of_10[static_cast<std::size_t>(19)];
-        res *= impl::powers_of_10[static_cast<std::size_t>(n - 19)];
-    }
-
-    return res;
+    return impl::builtin_128_pow10[static_cast<std::size_t>(n)];
 }
 
 #endif

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -43,6 +43,7 @@ project : requirements
 
 run-fail benchmarks.cpp ;
 run compare_dec128_and_fast.cpp ;
+run-fail compare_num_digits.cpp ;
 compile-fail concepts_test.cpp ;
 run github_issue_426.cpp ;
 run github_issue_448.cpp ;

--- a/test/compare_num_digits.cpp
+++ b/test/compare_num_digits.cpp
@@ -194,12 +194,46 @@ int main()
 }
 
 /*
-Output as run on Apple M1 with -march=native -O3 -std=c++23
+Output on Apple M1 with Clang-18
 ====== BEGIN OUTPUT ======
-        Naive: 2400667 ns (s=440000)
-Binary Search: 2287125 ns (s=440000)
-Linear Search: 2047792 ns (s=440000)
-          Log: 1982542 ns (s=440000)
+        Naive: 2328125 ns (s=440000)
+Binary Search: 1883042 ns (s=440000)
+Linear Search: 1669042 ns (s=440000)
+          Log: 1690542 ns (s=440000)
+
+
+EXIT STATUS: 1
+====== END OUTPUT ======
+
+Output on Apple M1 with GCC-14
+====== BEGIN OUTPUT ======
+        Naive: 716000 ns (s=440000)
+Binary Search: 410000 ns (s=440000)
+Linear Search: 473000 ns (s=440000)
+          Log: 400000 ns (s=440000)
+
+
+EXIT STATUS: 1
+====== END OUTPUT ======
+
+Output on x86_64 from CI with GCC-14
+====== BEGIN OUTPUT ======
+        Naive: 1259225 ns (s=440000)
+Binary Search: 890099 ns (s=440000)
+Linear Search: 971391 ns (s=440000)
+          Log: 828716 ns (s=440000)
+
+
+EXIT STATUS: 1
+====== END OUTPUT ======
+
+Output on x86_64 from CI with Clang-18
+====== BEGIN OUTPUT ======
+        Naive: 1946074 ns (s=440000)
+Binary Search: 912493 ns (s=440000)
+Linear Search: 1045009 ns (s=440000)
+          Log: 707485 ns (s=440000)
+
 
 EXIT STATUS: 1
 ====== END OUTPUT ======

--- a/test/compare_num_digits.cpp
+++ b/test/compare_num_digits.cpp
@@ -160,11 +160,6 @@ constexpr auto linear_search(std::uint32_t x) noexcept -> int
     return r;
 }
 
-constexpr auto base_two_dig(std::uint32_t x) noexcept -> int
-{
-    return x ? 32 - boost::decimal::detail::countl_zero(x) : 0;
-}
-
 static constexpr std::uint8_t guess[33] = {
         0, 0, 0, 0, 1, 1, 1, 2, 2, 2,
         3, 3, 3, 3, 4, 4, 4, 5, 5, 5,
@@ -179,7 +174,7 @@ static constexpr std::uint32_t tens[] = {
 
 constexpr auto log2_digits(std::uint32_t x) -> int
 {
-    const auto digits {guess[base_two_dig(x)]};
+    const auto digits {guess[32 - boost::decimal::detail::countl_zero(x)]};
     return digits + (x >= tens[digits]);
 }
 

--- a/test/compare_num_digits.cpp
+++ b/test/compare_num_digits.cpp
@@ -9,6 +9,8 @@
 #include <cassert>
 #include <boost/decimal/detail/countl.hpp>
 
+#ifdef BOOST_DECIMAL_RUN_NUM_DIGITS
+
 template <typename Func>
 void test(Func f, const char* title)
 {
@@ -192,6 +194,16 @@ int main()
 
     return 1;
 }
+
+#else
+
+int main()
+{
+    std::cout << "Num digits comp not run" << std::endl;
+    return 1;
+}
+
+#endif
 
 /*
 Output on Apple M1 with Clang-18

--- a/test/compare_num_digits.cpp
+++ b/test/compare_num_digits.cpp
@@ -1,0 +1,206 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <random>
+#include <chrono>
+#include <iostream>
+#include <cstdint>
+#include <cassert>
+#include <boost/decimal/detail/countl.hpp>
+
+template <typename Func>
+void test(Func f, const char* title)
+{
+    using namespace std::chrono_literals;
+
+    std::mt19937_64 rng(42);
+
+    // Check in ranges
+    std::uniform_int_distribution<std::uint32_t> two(10, 99);
+    std::uniform_int_distribution<std::uint32_t> three(100, 999);
+    std::uniform_int_distribution<std::uint32_t> four(1000, 9999);
+    std::uniform_int_distribution<std::uint32_t> five(10000, 99999);
+    std::uniform_int_distribution<std::uint32_t> six(100000, 999999);
+    std::uniform_int_distribution<std::uint32_t> seven(1000000, 9999999);
+    std::uniform_int_distribution<std::uint32_t> eight(10000000, 99999999);
+    std::uniform_int_distribution<std::uint32_t> nine(100000000, 999999999);
+
+    std::size_t discard {};
+
+    const auto t1 = std::chrono::steady_clock::now();
+
+    for (std::size_t loops {}; loops < 100; ++loops)
+    {
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(two(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 2);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(three(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 3);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(four(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 4);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(five(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 5);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(six(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 6);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(seven(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 7);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(eight(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 8);
+        }
+
+        for (std::size_t i {}; i < 100; ++i)
+        {
+            const auto res {f(nine(rng))};
+            discard += static_cast<std::size_t>(res);
+            assert(res == 9);
+        }
+    }
+
+    const auto t2 = std::chrono::steady_clock::now();
+
+    std::cout << title << ": " << ( t2 - t1 ) / 1ns << " ns (s=" << discard << ")\n";
+}
+
+constexpr auto naive(std::uint32_t x) noexcept -> int
+{
+    int digits = 0;
+
+    while (x)
+    {
+        x /= UINT32_C(10);
+        ++digits;
+    }
+
+    return digits;
+}
+
+constexpr auto binary_search(std::uint32_t x) noexcept -> int
+{
+    if (x >= UINT32_C(10000))
+    {
+        if (x >= UINT32_C(10000000))
+        {
+            if (x >= UINT32_C(100000000))
+            {
+                if (x >= UINT32_C(1000000000))
+                {
+                    return 10;
+                }
+                return 9;
+            }
+            return 8;
+        }
+
+        else if (x >= UINT32_C(100000))
+        {
+            if (x >= UINT32_C(1000000))
+            {
+                return 7;
+            }
+            return 6;
+        }
+        return 5;
+    }
+    else if (x >= UINT32_C(100))
+    {
+        if (x >= UINT32_C(1000))
+        {
+            return 4;
+        }
+        return 3;
+    }
+    else if (x >= UINT32_C(10))
+    {
+        return 2;
+    }
+
+    return 1;
+}
+
+constexpr auto linear_search(std::uint32_t x) noexcept -> int
+{
+    auto r = (x >= 1000000000) ? 10 : (x >= 100000000) ? 9 : (x >= 10000000) ? 8 :
+                            (x >= 1000000) ? 7 : (x >= 100000) ? 6 : (x >= 10000) ? 5 :
+                                     (x >= 1000) ? 4 : (x >= 100) ? 3 : (x >= 10) ? 2 : 1;
+    return r;
+}
+
+constexpr auto base_two_dig(std::uint32_t x) noexcept -> int
+{
+    return x ? 32 - boost::decimal::detail::countl_zero(x) : 0;
+}
+
+static constexpr std::uint8_t guess[33] = {
+        0, 0, 0, 0, 1, 1, 1, 2, 2, 2,
+        3, 3, 3, 3, 4, 4, 4, 5, 5, 5,
+        6, 6, 6, 6, 7, 7, 7, 8, 8, 8,
+        9, 9, 9
+};
+
+static constexpr std::uint32_t tens[] = {
+        1, 10, 100, 1000, 10000, 100000,
+        1000000, 10000000, 100000000, 1000000000,
+};
+
+constexpr auto log2_digits(std::uint32_t x) -> int
+{
+    const auto digits {guess[base_two_dig(x)]};
+    return digits + (x >= tens[digits]);
+}
+
+int main()
+{
+    test(naive, "        Naive");
+    test(binary_search, "Binary Search");
+    test(linear_search, "Linear Search");
+    test(log2_digits, "          Log");
+
+    std::cout << std::endl;
+
+    return 1;
+}
+
+/*
+Output as run on Apple M1 with -march=native -O3 -std=c++23
+====== BEGIN OUTPUT ======
+        Naive: 2400667 ns (s=440000)
+Binary Search: 2287125 ns (s=440000)
+Linear Search: 2047792 ns (s=440000)
+          Log: 1982542 ns (s=440000)
+
+EXIT STATUS: 1
+====== END OUTPUT ======
+ */

--- a/test/roundtrip_decimal128.cpp
+++ b/test/roundtrip_decimal128.cpp
@@ -388,7 +388,7 @@ void generate_powers_of_10()
 {
     detail::uint128 x {1};
 
-    for (std::uint64_t i {1}; i < 39; ++i)
+    for (std::uint64_t i {1}; i < 41; ++i)
     {
         std::cerr << "uint128 {UINT64_C(" << x.high << "), UINT64_C(" << x.low << ")}," << std::endl;
         x *= UINT64_C(10);

--- a/test/roundtrip_decimal128.cpp
+++ b/test/roundtrip_decimal128.cpp
@@ -383,6 +383,19 @@ void test_roundtrip_conversion_decimal32()
     }
 }
 
+#ifdef BOOST_DECIMAL_GENERATE_POW10
+void generate_powers_of_10()
+{
+    detail::uint128 x {1};
+
+    for (std::uint64_t i {1}; i < 39; ++i)
+    {
+        std::cerr << "uint128 {UINT64_C(" << x.high << "), UINT64_C(" << x.low << ")}," << std::endl;
+        x *= UINT64_C(10);
+    }
+}
+#endif
+
 int main()
 {
     test_conversion_to_integer<int>();
@@ -466,6 +479,10 @@ int main()
 
     test_spot(1.0655323219581014e+307);
     test_spot(9.46262809540089e+306);
+
+    #ifdef BOOST_DECIMAL_GENERATE_POW10
+    generate_powers_of_10();
+    #endif
 
     return boost::report_errors();
 }

--- a/test/roundtrip_decimal128.cpp
+++ b/test/roundtrip_decimal128.cpp
@@ -305,6 +305,30 @@ void test_roundtrip_float_stream()
     }
 }
 
+template <typename T>
+void test_spot(T val)
+{
+    const decimal128 first_val {val};
+    const T first_val_flt {static_cast<T>(first_val)};
+    std::stringstream ss;
+    ss << std::setprecision(std::numeric_limits<decimal128>::digits10);
+    ss << first_val;
+    decimal128 return_val {};
+    ss >> return_val;
+    const T return_val_flt {static_cast<T>(return_val)};
+
+    if (!BOOST_TEST_EQ(first_val, return_val) || !BOOST_TEST_EQ(first_val_flt, return_val_flt))
+    {
+        // LCOV_EXCL_START
+        std::cerr << std::setprecision(std::numeric_limits<T>::digits10)
+                  << "Val: " << first_val
+                  << "\nInt Val: " << first_val_flt
+                  << "\nRet: " << return_val
+                  << "\nInt Ret: " << return_val_flt << std::endl;
+        // LCOV_EXCL_STOP
+    }
+}
+
 template <>
 void test_roundtrip_float_stream<long double>()
 {
@@ -439,6 +463,9 @@ int main()
     #endif
 
     test_roundtrip_conversion_decimal32();
+
+    test_spot(1.0655323219581014e+307);
+    test_spot(9.46262809540089e+306);
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Currently we use binary search tree to figure out the number of digits in a number. Looks like in the case of `std::uint32_t` we could covert to log calculation with a >15% speedup. I expect similar speedups for uint64_t and __uint128_t where it is more desparately needed.

Closes: #643 