### PR TITLE
Faster dec128 fast

### DIFF
--- a/doc/decimal/benchmarks.adoc
+++ b/doc/decimal/benchmarks.adoc
@@ -53,8 +53,8 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 | 102,132
 | 16.367
 | `decimal128_fast`
-| 1,427,647
-| 228.790
+| 146,302
+| 23.446
 |===
 
 == Basic Operations
@@ -92,8 +92,8 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 | 139,294
 | 44.248
 | `decimal128_fast`
-| 1,351,882
-| 429.442
+| 707,308
+| 224.685
 |===
 
 ==== Subtraction
@@ -122,8 +122,8 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 | 145,606
 | 87.820
 | `decimal128_fast`
-| 894,695
-| 539.623
+| 394,538
+| 2387.960
 |===
 
 ==== Multiplication
@@ -152,8 +152,8 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 | 333,582
 | 193.943
 | `decimal128_fast`
-| 1,822,921
-| 1059.838
+| 1,269,429
+| 738.040
 |===
 
 ==== Division
@@ -182,8 +182,8 @@ Run using a Macbook pro with M1 pro chipset running macOS Sonoma 14.4.1 and home
 | 291,671
 | 75.289
 | `decimal128_fast`
-| 292,556
-| 75.518
+| 302,003
+| 77.956
 |===
 
 == Selected Special Functions

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -900,10 +900,7 @@ constexpr auto operator-(decimal128_fast lhs, Integer rhs) noexcept
 
     const bool abs_lhs_bigger {abs(lhs) > detail::make_positive_unsigned(rhs)};
 
-    auto sig_lhs {lhs.full_significand()};
-    auto exp_lhs {lhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_lhs, exp_lhs);
-    auto lhs_components {detail::decimal128_fast_components{sig_lhs, exp_lhs, lhs.isneg()}};
+    auto lhs_components {detail::decimal128_fast_components{lhs.significand_, lhs.biased_exponent(), lhs.isneg()}};
 
     auto sig_rhs {static_cast<detail::uint128>(detail::make_positive_unsigned(rhs))};
     std::int32_t exp_rhs {0};
@@ -943,10 +940,7 @@ constexpr auto operator-(Integer lhs, decimal128_fast rhs) noexcept
     auto unsigned_sig_lhs {detail::make_positive_unsigned(sig_lhs)};
     auto lhs_components {detail::decimal128_fast_components{unsigned_sig_lhs, exp_lhs, (lhs < 0)}};
 
-    auto sig_rhs {rhs.full_significand()};
-    auto exp_rhs {rhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_rhs, exp_rhs);
-    auto rhs_components {detail::decimal128_fast_components{sig_rhs, exp_rhs, rhs.isneg()}};
+    auto rhs_components {detail::decimal128_fast_components{rhs.significand_, rhs.biased_exponent(), rhs.isneg()}};
 
     const auto result {detail::d128_sub_impl<detail::decimal128_fast_components>(
             lhs_components.sig, lhs_components.exp, lhs_components.sign,

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -1072,7 +1072,7 @@ constexpr auto d128f_div_impl(decimal128_fast lhs, decimal128_fast rhs, decimal1
     #else
     static_cast<void>(r);
     #endif
-    
+
     #ifdef BOOST_DECIMAL_DEBUG
     std::cerr << "sig lhs: " << sig_lhs
               << "\nexp lhs: " << exp_lhs
@@ -1138,11 +1138,7 @@ constexpr auto operator/(decimal128_fast lhs, Integer rhs) noexcept
     }
     #endif
 
-    auto lhs_sig {lhs.full_significand()};
-    auto lhs_exp {lhs.biased_exponent()};
-    detail::normalize<decimal128>(lhs_sig, lhs_exp);
-
-    detail::decimal128_fast_components lhs_components {lhs_sig, lhs_exp, lhs.isneg()};
+    detail::decimal128_fast_components lhs_components {lhs.significand_, lhs.biased_exponent(), lhs.isneg()};
 
     auto rhs_sig {detail::make_positive_unsigned(rhs)};
     std::int32_t rhs_exp {};
@@ -1184,12 +1180,8 @@ constexpr auto operator/(Integer lhs, decimal128_fast rhs) noexcept
     }
     #endif
 
-    auto rhs_sig {rhs.full_significand()};
-    auto rhs_exp {rhs.biased_exponent()};
-    detail::normalize<decimal128>(rhs_sig, rhs_exp);
-
     detail::decimal128_fast_components lhs_components {detail::make_positive_unsigned(lhs), 0, lhs < 0};
-    detail::decimal128_fast_components rhs_components {rhs_sig, rhs_exp, rhs.isneg()};
+    detail::decimal128_fast_components rhs_components {rhs.significand_, rhs.biased_exponent(), rhs.isneg()};
     detail::decimal128_fast_components q_components {};
 
     detail::d128_generic_div_impl(lhs_components, rhs_components, q_components);

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -806,10 +806,7 @@ constexpr auto operator+(decimal128_fast lhs, Integer rhs) noexcept
     }
     bool abs_lhs_bigger {abs(lhs) > detail::make_positive_unsigned(rhs)};
 
-    auto sig_lhs {lhs.full_significand()};
-    auto exp_lhs {lhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_lhs, exp_lhs);
-    auto lhs_components {detail::decimal128_fast_components{sig_lhs, exp_lhs, lhs.isneg()}};
+    auto lhs_components {detail::decimal128_fast_components{lhs.significand_, lhs.biased_exponent(), lhs.isneg()}};
 
     auto sig_rhs {static_cast<detail::uint128>(detail::make_positive_unsigned(rhs))};
     std::int32_t exp_rhs {0};

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -873,17 +873,9 @@ constexpr auto operator-(decimal128_fast lhs, decimal128_fast rhs) noexcept -> d
 
     const bool abs_lhs_bigger {abs(lhs) > abs(rhs)};
 
-    auto sig_lhs {lhs.full_significand()};
-    auto exp_lhs {lhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_lhs, exp_lhs);
-
-    auto sig_rhs {rhs.full_significand()};
-    auto exp_rhs {rhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_rhs, exp_rhs);
-
     const auto result {detail::d128_sub_impl<detail::decimal128_fast_components>(
-            sig_lhs, exp_lhs, lhs.sign_,
-            sig_rhs, exp_rhs, rhs.sign_,
+            lhs.significand_, lhs.biased_exponent(), lhs.sign_,
+            rhs.significand_, rhs.biased_exponent(), rhs.sign_,
             abs_lhs_bigger
     )};
 

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -781,17 +781,9 @@ constexpr auto operator+(decimal128_fast lhs, decimal128_fast rhs) noexcept -> d
         return lhs - abs(rhs);
     }
 
-    auto lhs_sig {lhs.full_significand()};
-    auto lhs_exp {lhs.biased_exponent()};
-    detail::normalize<decimal128>(lhs_sig, lhs_exp);
-
-    auto rhs_sig {rhs.full_significand()};
-    auto rhs_exp {rhs.biased_exponent()};
-    detail::normalize<decimal128>(rhs_sig, rhs_exp);
-
     const auto result {detail::d128_add_impl<detail::decimal128_fast_components>(
-            lhs_sig, lhs_exp, lhs.sign_,
-            rhs_sig, rhs_exp, rhs.sign_)};
+            lhs.significand_, lhs.biased_exponent(), lhs.sign_,
+            rhs.significand_, rhs.biased_exponent(), rhs.sign_)};
 
     return {result.sig, result.exp, result.sign};
 };

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -546,8 +546,17 @@ constexpr auto operator<(const decimal128_fast& lhs, const decimal128_fast& rhs)
     }
 #endif
 
-    return less_parts_impl<decimal128>(lhs.significand_, lhs.biased_exponent(), lhs.sign_,
-                                       rhs.significand_, rhs.biased_exponent(), rhs.sign_);
+    if (lhs.significand_ == 0 || rhs.significand_ == 0)
+    {
+        return lhs.significand_ == 0 ? !rhs.sign_ : lhs.sign_;
+    }
+
+    if (lhs.exponent_ != rhs.exponent_)
+    {
+        return lhs.sign_ ? lhs.exponent_ > rhs.exponent_ : lhs.exponent_ < rhs.exponent_;
+    }
+
+    return lhs.sign_ ? lhs.significand_ > rhs.significand_ : lhs.significand_ < rhs.significand_;
 }
 
 template <typename Integer>

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -351,50 +351,24 @@ template <typename T1, typename T2, std::enable_if_t<detail::is_integral_v<T1> &
 #endif
 constexpr decimal128_fast::decimal128_fast(T1 coeff, T2 exp, bool sign) noexcept
 {
-    using Unsigned_Integer = detail::make_unsigned_t<T1>;
-
     const bool isneg {coeff < static_cast<T1>(0) || sign};
     sign_ = isneg;
-    Unsigned_Integer unsigned_coeff {detail::make_positive_unsigned(coeff)};
+    auto unsigned_coeff {static_cast<significand_type>(detail::make_positive_unsigned(coeff))};
 
-    auto unsigned_coeff_digits {detail::num_digits(unsigned_coeff)};
-    const bool reduced {unsigned_coeff_digits > detail::precision_v<decimal128>};
+    // Normalize the significand in the constructor, so we don't have
+    // to calculate the number of digits for operationss
+    detail::normalize<decimal128>(unsigned_coeff, exp, sign);
 
-    // Strip digits
-    if (unsigned_coeff_digits > detail::precision_v<decimal128> + 1)
-    {
-        const auto digits_to_remove {unsigned_coeff_digits - (detail::precision_v<decimal128> + 1)};
+    significand_ = unsigned_coeff;
 
-        #if defined(__GNUC__) && !defined(__clang__)
-        #  pragma GCC diagnostic push
-        #  pragma GCC diagnostic ignored "-Wconversion"
-        #endif
-
-        unsigned_coeff /= detail::pow10(static_cast<Unsigned_Integer>(digits_to_remove));
-
-        #if defined(__GNUC__) && !defined(__clang__)
-        #  pragma GCC diagnostic pop
-        #endif
-
-        exp += digits_to_remove;
-        unsigned_coeff_digits -= digits_to_remove;
-    }
-
-    // Round as required
-    if (reduced)
-    {
-        exp += static_cast<T2>(detail::fenv_round(unsigned_coeff, isneg));
-    }
-
-    significand_ = static_cast<significand_type>(unsigned_coeff);
-
-    // Normalize the handling of zeros
+    // Normalize the handling of 0
     if (significand_ == detail::uint128{UINT64_C(0), UINT64_C(0)})
     {
         exp = 0;
     }
 
     const auto biased_exp {static_cast<exponent_type>(exp + detail::bias_v<decimal128>)};
+
     if (biased_exp > detail::max_biased_exp_v<decimal128>)
     {
         significand_ = detail::d128_fast_inf;

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -1072,15 +1072,7 @@ constexpr auto d128f_div_impl(decimal128_fast lhs, decimal128_fast rhs, decimal1
     #else
     static_cast<void>(r);
     #endif
-
-    auto sig_lhs {lhs.full_significand()};
-    auto exp_lhs {lhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_lhs, exp_lhs);
-
-    auto sig_rhs {rhs.full_significand()};
-    auto exp_rhs {rhs.biased_exponent()};
-    detail::normalize<decimal128>(sig_rhs, exp_rhs);
-
+    
     #ifdef BOOST_DECIMAL_DEBUG
     std::cerr << "sig lhs: " << sig_lhs
               << "\nexp lhs: " << exp_lhs
@@ -1088,8 +1080,8 @@ constexpr auto d128f_div_impl(decimal128_fast lhs, decimal128_fast rhs, decimal1
               << "\nexp rhs: " << exp_rhs << std::endl;
     #endif
 
-    detail::decimal128_fast_components lhs_components {sig_lhs, exp_lhs, lhs.isneg()};
-    detail::decimal128_fast_components rhs_components {sig_rhs, exp_rhs, rhs.isneg()};
+    detail::decimal128_fast_components lhs_components {lhs.significand_, lhs.biased_exponent(), lhs.isneg()};
+    detail::decimal128_fast_components rhs_components {rhs.significand_, rhs.biased_exponent(), rhs.isneg()};
     detail::decimal128_fast_components q_components {};
 
     detail::d128_generic_div_impl(lhs_components, rhs_components, q_components);

--- a/include/boost/decimal/detail/add_impl.hpp
+++ b/include/boost/decimal/detail/add_impl.hpp
@@ -220,24 +220,23 @@ constexpr auto d128_add_impl(T1 lhs_sig, std::int32_t lhs_exp, bool lhs_sign,
     {
         lhs_sig *= detail::pow10(static_cast<detail::uint128>(delta_exp));
         lhs_exp -= delta_exp;
-        delta_exp = 0;
     }
     else
     {
         lhs_sig *= 1000;
         delta_exp -= 3;
         lhs_exp -= 3;
-    }
 
-    while (delta_exp > 1)
-    {
-        rhs_sig /= detail::pow10(static_cast<detail::uint128>(delta_exp - 1));
-        delta_exp = 1;
-    }
+        if (delta_exp > 1)
+        {
+            rhs_sig /= pow10(static_cast<uint128>(delta_exp - 1));
+            delta_exp = 1;
+        }
 
-    if (delta_exp == 1)
-    {
-        detail::fenv_round<decimal128>(rhs_sig, rhs_sign);
+        if (delta_exp == 1)
+        {
+            detail::fenv_round<decimal128>(rhs_sig, rhs_sign);
+        }
     }
 
     const auto new_sig {static_cast<typename ReturnType::sig_type>(lhs_sig) +


### PR DESCRIPTION
Closes: #656 

Provides 2.375x speedup vs develop and 3.236x speedup vs `decimal128`