### PR TITLE
Improve `num_digits()` for `uint256_t`

### DIFF
--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -168,24 +168,6 @@ constexpr auto num_digits(std::uint64_t x) noexcept -> int
 # pragma warning(disable: 4307) // MSVC 14.1 warns of intergral constant overflow
 #endif
 
-#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
-
-template <typename T, std::size_t N>
-constexpr auto generate_array() noexcept -> std::array<T, N>
-{
-    std::array<T, N> values {};
-
-    values[0] = T{1};
-    for (std::size_t i {1}; i < N; ++i)
-    {
-        values[i] = values[i - 1] * UINT64_C(10);
-    }
-
-    return values;
-}
-
-#else
-
 constexpr int num_digits(const uint128& x) noexcept
 {
     if (x.high == UINT64_C(0))
@@ -214,41 +196,6 @@ constexpr int num_digits(const uint128& x) noexcept
     return static_cast<int>(left + 1);
 }
 
-#endif // Constexpr array
-
-#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
-
-constexpr int num_digits(const uint256_t& x) noexcept
-{
-    constexpr auto big_powers_of_10 = generate_array<boost::decimal::detail::uint256_t, 79>();
-
-    if (x.high == UINT64_C(0) && x.low == UINT64_C(0))
-    {
-        return 1;
-    }
-
-    std::uint32_t left = 0U;
-    std::uint32_t right = 78U;
-
-    while (left < right)
-    {
-        std::uint32_t mid = (left + right + 1U) / 2U;
-
-        if (x >= big_powers_of_10[mid])
-        {
-            left = mid;
-        }
-        else
-        {
-            right = mid - 1;
-        }
-    }
-
-    return static_cast<int>(left + 1);
-}
-
-#else
-
 constexpr int num_digits(const uint256_t& x) noexcept
 {
     if (x.high == 0)
@@ -276,46 +223,11 @@ constexpr int num_digits(const uint256_t& x) noexcept
     return 1;
 }
 
-#endif // Constexpr arrays
-
 #ifdef _MSC_VER
 # pragma warning(pop)
 #endif
 
 #ifdef BOOST_DECIMAL_HAS_INT128
-
-#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
-
-constexpr auto num_digits(boost::decimal::detail::uint128_t x) noexcept -> int
-{
-    constexpr auto big_powers_of_10 = generate_array<boost::decimal::detail::uint128_t, 39>();
-
-    if (x == 0)
-    {
-        return 1;
-    }
-
-    std::uint32_t left = 0U;
-    std::uint32_t right = 38U;
-
-    while (left < right)
-    {
-        std::uint32_t mid = (left + right + 1U) / 2U;
-
-        if (x >= big_powers_of_10[mid])
-        {
-            left = mid;
-        }
-        else
-        {
-            right = mid - 1;
-        }
-    }
-
-    return static_cast<int>(left + 1);
-}
-
-#else
 
 constexpr auto num_digits(const uint128_t& x) noexcept -> int
 {
@@ -344,8 +256,6 @@ constexpr auto num_digits(const uint128_t& x) noexcept -> int
 
     return static_cast<int>(left + 1);
 }
-
-#endif // constexpr arrays
 
 #endif // Has int128
 

--- a/include/boost/decimal/detail/integer_search_trees.hpp
+++ b/include/boost/decimal/detail/integer_search_trees.hpp
@@ -203,12 +203,8 @@ constexpr int num_digits(const uint256_t& x) noexcept
         return num_digits(x.low);
     }
 
-    constexpr uint256_t max_digits = umul256({static_cast<uint128>(UINT64_C(10000000000000000000)) *
-                                              static_cast<uint128>(UINT64_C(10000000000000000000))},
-                                              {static_cast<uint128>(UINT64_C(10000000000000000000)) *
-                                               static_cast<uint128>(UINT64_C(10000000000000000000))});
-
-    uint256_t current_power_of_10 = max_digits;
+    // 10^77
+    auto current_power_of_10 {uint256_t{uint128{UINT64_C(15930919111324522770), UINT64_C(5327493063679123134)}, uint128{UINT64_C(12292710897160462336), UINT64_C(0)}}};
 
     for (int i = 78; i > 0; --i)
     {

--- a/test/test_big_uints.cpp
+++ b/test/test_big_uints.cpp
@@ -458,6 +458,21 @@ auto test_big_uints_shl() -> void
   }
 }
 
+template <typename T>
+void test_digit_counting()
+{
+    constexpr auto max_power {std::is_same<T, boost::decimal::detail::uint256_t>::value ? 77 : 38 };
+
+    T current_power {1};
+    int current_digits {1};
+    for (int i {}; i <= max_power; ++i)
+    {
+        BOOST_TEST_EQ(num_digits(current_power), current_digits);
+        current_power = current_power * UINT64_C(10);
+        ++current_digits;
+    }
+}
+
 int main()
 {
   test_big_uints_mul<boost::multiprecision::uint128_t, boost::decimal::detail::uint128  >();
@@ -474,6 +489,9 @@ int main()
 
   test_big_uints_shl<boost::multiprecision::uint128_t, boost::decimal::detail::uint128  >();
   test_big_uints_shl<boost::multiprecision::uint256_t, boost::decimal::detail::uint256_t>();
+
+  test_digit_counting<boost::decimal::detail::uint128>();
+  test_digit_counting<boost::decimal::detail::uint256_t>();
 
   return boost::report_errors();
 }


### PR DESCRIPTION
Improves `decimal128` by 6.369x and `decimal128_fast` by 4.651 in >=C++17 modes.