### PR TITLE
Improved comparisons for `decimal64`

### DIFF
--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -1625,16 +1625,7 @@ constexpr auto decimal64::operator%=(decimal64 rhs) noexcept -> decimal64&
 
 constexpr auto operator==(decimal64 lhs, decimal64 rhs) noexcept -> bool
 {
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Check for IEEE requirement that nan != nan
-    if (isnan(lhs) || isnan(rhs))
-    {
-        return false;
-    }
-    #endif
-
-    return equal_parts_impl<decimal64>(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
-                                       rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
+    return equality_impl(lhs, rhs);
 }
 
 template <typename Integer>

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -222,6 +222,9 @@ private:
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto equality_impl(DecimalType lhs, DecimalType rhs) noexcept -> bool;
 
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
+    friend constexpr auto sequential_less_impl(DecimalType lhs, DecimalType rhs) noexcept -> bool;
+
 public:
     // 3.2.3.1 construct/copy/destroy
     constexpr decimal64() noexcept = default;
@@ -1682,8 +1685,7 @@ constexpr auto operator<(decimal64 lhs, decimal64 rhs) noexcept -> bool
     }
     #endif
 
-    return less_parts_impl<decimal64>(lhs.full_significand(), lhs.biased_exponent(), lhs.isneg(),
-                                      rhs.full_significand(), rhs.biased_exponent(), rhs.isneg());
+    return sequential_less_impl(lhs, rhs);
 }
 
 template <typename Integer>

--- a/include/boost/decimal/detail/comparison.hpp
+++ b/include/boost/decimal/detail/comparison.hpp
@@ -245,7 +245,13 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto fast_type_less_parts_impl(T lhs_sig, U
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
 constexpr auto sequential_less_impl(DecimalType lhs, DecimalType rhs) noexcept -> bool
 {
-    using comp_type = std::uint_fast64_t;
+    using comp_type = std::conditional_t<std::is_same<DecimalType, decimal32>::value, std::uint_fast64_t,
+    #ifdef BOOST_DECIMAL_HAS_INT128
+    detail::uint128_t
+    #else
+    detail::uint128
+    #endif
+    >;
 
     // Step 1: Handle our non-finite values in their own calling functions
 
@@ -279,7 +285,7 @@ constexpr auto sequential_less_impl(DecimalType lhs, DecimalType rhs) noexcept -
     auto rhs_exp {rhs.biased_exponent()};
 
     const auto delta_exp {lhs_exp - rhs_exp};
-    constexpr auto max_delta_diff {std::numeric_limits<std::uint_fast64_t>::digits10 - detail::precision_v<DecimalType>};
+    constexpr auto max_delta_diff {std::numeric_limits<comp_type>::digits10 - detail::precision_v<DecimalType>};
 
     if (delta_exp > max_delta_diff || delta_exp < -max_delta_diff)
     {

--- a/include/boost/decimal/detail/comparison.hpp
+++ b/include/boost/decimal/detail/comparison.hpp
@@ -51,17 +51,18 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto equality_impl(DecimalType lhs, Decimal
     const auto lhs_exp {lhs.biased_exponent()};
     const auto rhs_exp {rhs.biased_exponent()};
 
+    auto lhs_sig {lhs.full_significand()};
+    auto rhs_sig {rhs.full_significand()};
+
     const auto delta_exp {lhs_exp - rhs_exp};
 
-    if (delta_exp > detail::precision_v<DecimalType> || delta_exp < -detail::precision_v<DecimalType>)
+    if (delta_exp > detail::precision_v<DecimalType> || delta_exp < -detail::precision_v<DecimalType> ||
+        ((lhs_sig == static_cast<comp_type>(0)) ^ (rhs_sig == static_cast<comp_type>(0))))
     {
         return false;
     }
 
     // Step 5: Normalize the significand and compare
-    auto lhs_sig {lhs.full_significand()};
-    auto rhs_sig {rhs.full_significand()};
-
     delta_exp >= 0 ? lhs_sig *= detail::pow10(static_cast<comp_type>(delta_exp)) :
                      rhs_sig *= detail::pow10(static_cast<comp_type>(-delta_exp));
 


### PR DESCRIPTION
Provides a >30% speedup to `decimal64`s comparisons timing