### PR TITLE
Add support for b2 modular builds and boostlook

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,20 @@
+# Copyright René Ferdinand Rivera Morell 2023-2024
+# Copyright Matt Borland 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+require-b2 5.2 ;
+
+project /boost/decimal
+    : common-requirements
+        <include>include
+    ;
+
+explicit
+    [ alias boost_core ]
+    [ alias all : boost_decimal test ]
+    ;
+
+call-if : boost-library decimal
+    ;

--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -1,10 +1,14 @@
 # Copyright 2017, 2018 Peter Dimov
+# Copyright 2024 Matt Borland
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
 import asciidoctor ;
 
-html decimal.html : decimal.adoc ;
+html decimal.html : decimal.adoc
+    :   <use>/boost/boostlook//boostlook
+        <dependency>decimal-docinfo-footer.html
+    ;
 
 install html_ : decimal.html : <location>html ;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -4,12 +4,13 @@
 # Distributed under the Boost Software License, Version 1.0.
 # https://www.boost.org/LICENSE_1_0.txt
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
+import modules ;
 import testing ;
-import ../../config/checks/config : requires ;
 
 project : requirements
-
-  <library>/boost/charconv//boost_charconv
 
   <toolset>gcc:<cxxflags>-Wall
   <toolset>gcc:<cxxflags>-Wextra
@@ -113,7 +114,7 @@ run test_fixed_width_trunc.cpp ;
 run test_float_conversion.cpp ;
 run-fail test_fprintf.cpp ;
 run test_frexp_ldexp.cpp ;
-run test_from_chars.cpp ;
+run test_from_chars.cpp /boost/charconv//boost_charconv ;
 run test_git_issue_266.cpp ;
 run test_git_issue_271.cpp ;
 run test_hash.cpp ;


### PR DESCRIPTION
Updates our toolchain to support b2's modular format. Also adds support for boost look which is an improvement over the regular asciidoctor layout