### PR TITLE
Add literals for fast types

### DIFF
--- a/doc/decimal/literals.adoc
+++ b/doc/decimal/literals.adoc
@@ -19,7 +19,7 @@ constexpr auto operator  "" _DF(const char* str) -> decimal32
 constexpr auto operator  "" _df(const char* str) -> decimal32
 
 constexpr auto operator  "" _DF(unsigned long long v) -> decimal32
-constexpr auto operator  "" _dF(unsigned long long v) -> decimal32
+constexpr auto operator  "" _df(unsigned long long v) -> decimal32
 
 constexpr auto operator  "" _DD(const char* str) -> decimal64
 constexpr auto operator  "" _dd(const char* str) -> decimal64
@@ -32,6 +32,26 @@ constexpr auto operator  "" _dl(const char* str) -> decimal128
 
 constexpr auto operator  "" _DL(unsigned long long v) -> decimal128
 constexpr auto operator  "" _dl(unsigned long long v) -> decimal128
+
+// ----- Fast Type Literals -----
+
+constexpr auto operator  "" _DFF(const char* str) -> decimal32_fast
+constexpr auto operator  "" _dff(const char* str) -> decimal32_fast
+
+constexpr auto operator  "" _DFF(unsigned long long v) -> decimal32_fast
+constexpr auto operator  "" _dff(unsigned long long v) -> decimal32_fast
+
+constexpr auto operator  "" _DDF(const char* str) -> decimal64_fast
+constexpr auto operator  "" _ddf(const char* str) -> decimal64_fast
+
+constexpr auto operator  "" _DDF(unsigned long long v) -> decimal64_fast
+constexpr auto operator  "" _ddf(unsigned long long v) -> decimal64_fast
+
+constexpr auto operator  "" _DLF(const char* str) -> decimal128_fast
+constexpr auto operator  "" _dlf(const char* str) -> decimal128_fast
+
+constexpr auto operator  "" _DLF(unsigned long long v) -> decimal128_fast
+constexpr auto operator  "" _dlf(unsigned long long v) -> decimal128_fast
 
 } //namespace decimal
 } //namespace boost

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -385,7 +385,7 @@ constexpr decimal32_fast::decimal32_fast(T1 coeff, T2 exp, bool sign) noexcept
     auto biased_exp {static_cast<std::uint_fast32_t>(exp + detail::bias)};
 
     // Decimal32 exponent holds 8 bits
-    if (biased_exp > UINT32_C(0xFF))
+    if (biased_exp > detail::max_biased_exp_v<decimal32_fast>)
     {
         significand_ = detail::d32_fast_inf;
     }

--- a/include/boost/decimal/literals.hpp
+++ b/include/boost/decimal/literals.hpp
@@ -34,17 +34,17 @@ BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(const char* str) -> decimal
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(const char* str, std::size_t) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(const char* str, std::size_t len) -> decimal32
 {
     decimal32 d;
-    from_chars(str, str + detail::strlen(str), d);
+    from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(const char* str, std::size_t) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(const char* str, std::size_t len) -> decimal32
 {
     decimal32 d;
-    from_chars(str, str + detail::strlen(str), d);
+    from_chars(str, str + len, d);
     return d;
 }
 
@@ -56,6 +56,44 @@ BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(unsigned long long v) -> de
 BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(unsigned long long v) -> decimal32
 {
     return decimal32{v};
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(const char* str) -> decimal32_fast
+{
+    decimal32_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(const char* str) -> decimal32_fast
+{
+    decimal32_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(const char* str, std::size_t len) -> decimal32_fast
+{
+    decimal32_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(const char* str, std::size_t len) -> decimal32_fast
+{
+    decimal32_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(unsigned long long v) -> decimal32_fast
+{
+    return decimal32_fast{v};
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(unsigned long long v) -> decimal32_fast
+{
+    return decimal32_fast{v};
 }
 
 BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DD(const char* str) -> decimal64
@@ -96,6 +134,44 @@ BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dd(unsigned long long v) -> de
     return decimal64{v};
 }
 
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(const char* str) -> decimal64_fast
+{
+    decimal64_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(const char* str) -> decimal64_fast
+{
+    decimal64_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(const char* str, std::size_t len) -> decimal64_fast
+{
+    decimal64_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(const char* str, std::size_t len) -> decimal64_fast
+{
+    decimal64_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(unsigned long long v) -> decimal64_fast
+{
+    return decimal64_fast{v};
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(unsigned long long v) -> decimal64_fast
+{
+    return decimal64_fast{v};
+}
+
 BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DL(const char* str) -> decimal128
 {
     decimal128 d;
@@ -132,6 +208,44 @@ BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DL(unsigned long long v) -> de
 BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dl(unsigned long long v) -> decimal128
 {
     return decimal128{v};
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(const char* str) -> decimal128_fast
+{
+    decimal128_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(const char* str) -> decimal128_fast
+{
+    decimal128_fast d;
+    from_chars(str, str + detail::strlen(str), d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(const char* str, std::size_t len) -> decimal128_fast
+{
+    decimal128_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(const char* str, std::size_t len) -> decimal128_fast
+{
+    decimal128_fast d;
+    from_chars(str, str + len, d);
+    return d;
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(unsigned long long v) -> decimal128_fast
+{
+    return decimal128_fast{v};
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(unsigned long long v) -> decimal128_fast
+{
+    return decimal128_fast{v};
 }
 
 } // namespace decimal

--- a/test/test_literals.cpp
+++ b/test/test_literals.cpp
@@ -26,6 +26,23 @@ void test_decimal32_literals()
     BOOST_TEST(isinf(5e300_df));
 }
 
+void test_decimal32_fast_literals()
+{
+    BOOST_TEST_EQ(decimal32_fast(0), 0_DFF);
+    BOOST_TEST_EQ(decimal32_fast(3), 3_DFF);
+    BOOST_TEST_EQ(decimal32_fast(3.1), 3.1_DFF);
+    BOOST_TEST_EQ(decimal32_fast(3, 1), 3e1_DFF);
+    BOOST_TEST(isinf(5e100_DFF));
+    BOOST_TEST(isinf(5e300_DFF));
+
+    BOOST_TEST_EQ(decimal32_fast(0), 0_dff);
+    BOOST_TEST_EQ(decimal32_fast(3), 3_dff);
+    BOOST_TEST_EQ(decimal32_fast(3.1), 3.1_dff);
+    BOOST_TEST_EQ(decimal32_fast(3, 1), 3e1_dff);
+    BOOST_TEST(isinf(5e100_dff));
+    BOOST_TEST(isinf(5e300_dff));
+}
+
 void test_decimal64_literals()
 {
     BOOST_TEST_EQ(decimal64(0), 0_DD);
@@ -47,6 +64,27 @@ void test_decimal64_literals()
     #endif
 }
 
+void test_decimal64_fast_literals()
+{
+    BOOST_TEST_EQ(decimal64_fast(0), 0_DDF);
+    BOOST_TEST_EQ(decimal64_fast(3), 3_DDF);
+    BOOST_TEST_EQ(decimal64_fast(3.1), 3.1_DDF);
+    BOOST_TEST_EQ(decimal64_fast(3, 1), 3e1_DDF);
+
+    BOOST_TEST_EQ(decimal64_fast(0), 0_ddf);
+    BOOST_TEST_EQ(decimal64_fast(3), 3_ddf);
+    BOOST_TEST_EQ(decimal64_fast(3.1), 3.1_ddf);
+    BOOST_TEST_EQ(decimal64_fast(3, 1), 3e1_ddf);
+
+    // 64-bit long double warn of overflow
+    #if !(LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024)
+    BOOST_TEST(isinf(5e1000_ddf));
+    BOOST_TEST(isinf(5e3000_ddf));
+    BOOST_TEST(isinf(5e1000_DDF));
+    BOOST_TEST(isinf(5e3000_DDF));
+    #endif
+}
+
 void test_decimal128_literals()
 {
     BOOST_TEST_EQ(decimal128(0), 0_DL);
@@ -60,11 +98,28 @@ void test_decimal128_literals()
     BOOST_TEST_EQ(decimal128(3, 1), 3e1_dl);
 }
 
+void test_decimal128_fast_literals()
+{
+    BOOST_TEST_EQ(decimal128_fast(0), 0_DLF);
+    BOOST_TEST_EQ(decimal128_fast(3), 3_DLF);
+    BOOST_TEST_EQ(decimal128_fast(3.1), 3.1_DLF);
+    BOOST_TEST_EQ(decimal128_fast(3, 1), 3e1_DLF);
+
+    BOOST_TEST_EQ(decimal128_fast(0), 0_dlf);
+    BOOST_TEST_EQ(decimal128_fast(3), 3_dlf);
+    BOOST_TEST_EQ(decimal128_fast(3.1), 3.1_dlf);
+    BOOST_TEST_EQ(decimal128_fast(3, 1), 3e1_dlf);
+}
+
 int main()
 {
     test_decimal32_literals();
     test_decimal64_literals();
     test_decimal128_literals();
+
+    test_decimal32_fast_literals();
+    test_decimal64_fast_literals();
+    test_decimal128_fast_literals();
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Closes: #751 

Also fixes the range of dec32_fast being slightly larger than it should be, and a typo in the dec32 literals docs