### PR TITLE
Enable 80 and 128 bit long double conversions

### DIFF
--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -970,8 +970,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal64::operator double() const noexcept
 
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal64::operator long double() const noexcept
 {
-    // TODO(mborland): Don't have an exact way of converting to various long doubles
-    return static_cast<long double>(to_float<decimal64, double>(*this));
+    return to_float<decimal64, long double>(*this);
 }
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16

--- a/include/boost/decimal/decimal64_fast.hpp
+++ b/include/boost/decimal/decimal64_fast.hpp
@@ -885,8 +885,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_fast::operator double() const noexcept
 
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_fast::operator long double() const noexcept
 {
-    // TODO(mborland): Don't have an exact way of converting to various long doubles
-    return static_cast<long double>(to_float<decimal64_fast, double>(*this));
+    return to_float<decimal64_fast, long double>(*this);
 }
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16

--- a/include/boost/decimal/detail/fast_float/compute_float80_128.hpp
+++ b/include/boost/decimal/detail/fast_float/compute_float80_128.hpp
@@ -69,8 +69,8 @@ constexpr auto fast_path(const std::int64_t q, const Unsigned_Integer &w, bool n
 #endif
 
 template <typename Unsigned_Integer>
-constexpr auto compute_float80(std::int64_t q, const Unsigned_Integer &w,
-                               const bool negative, bool &success) noexcept -> long double
+constexpr auto compute_float80_128(std::int64_t q, const Unsigned_Integer &w,
+                                   const bool negative, bool &success) noexcept -> long double
 {
     // GLIBC uses 2^-16444 but MPFR uses 2^-16445 as the smallest subnormal value for 80 bit
     // 39 is the max number of digits in an uint128_t

--- a/include/boost/decimal/detail/to_float.hpp
+++ b/include/boost/decimal/detail/to_float.hpp
@@ -72,10 +72,9 @@ BOOST_DECIMAL_CXX20_CONSTEXPR auto to_float(Decimal val) noexcept
         #if BOOST_DECIMAL_LDBL_BITS == 64
         result = static_cast<TargetType>(detail::fast_float::compute_float64(exp, new_sig, val.isneg(), success));
         #else
-        result = static_cast<TargetType>(detail::fast_float::compute_float80(exp, new_sig, val.isneg(), success));
+        result = static_cast<TargetType>(detail::fast_float::compute_float80_128(exp, new_sig, val.isneg(), success));
         #endif
     }
-    // TODO(mborland): Add conversion for __float128 and 128 bit long doubles
 
     if (BOOST_DECIMAL_UNLIKELY(!success))
     {


### PR DESCRIPTION
I think it's best to not offer `__float128` support until demanded based off all the issue that charconv has had because of that decision.