### PR TITLE
Fix deprecated whitespace in literal definition

### DIFF
--- a/include/boost/decimal/literals.hpp
+++ b/include/boost/decimal/literals.hpp
@@ -18,232 +18,233 @@
 #include <cstring>
 #endif
 
-namespace boost { namespace decimal {
+namespace boost {
+namespace decimal {
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(const char* str) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DF(const char* str) -> decimal32
 {
     decimal32 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(const char* str) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_df(const char* str) -> decimal32
 {
     decimal32 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(const char* str, std::size_t len) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DF(const char* str, std::size_t len) -> decimal32
 {
     decimal32 d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(const char* str, std::size_t len) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_df(const char* str, std::size_t len) -> decimal32
 {
     decimal32 d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DF(unsigned long long v) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DF(unsigned long long v) -> decimal32
 {
     return decimal32{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _df(unsigned long long v) -> decimal32
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_df(unsigned long long v) -> decimal32
 {
     return decimal32{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(const char* str) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DFF(const char* str) -> decimal32_fast
 {
     decimal32_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(const char* str) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dff(const char* str) -> decimal32_fast
 {
     decimal32_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(const char* str, std::size_t len) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DFF(const char* str, std::size_t len) -> decimal32_fast
 {
     decimal32_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(const char* str, std::size_t len) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dff(const char* str, std::size_t len) -> decimal32_fast
 {
     decimal32_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DFF(unsigned long long v) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DFF(unsigned long long v) -> decimal32_fast
 {
     return decimal32_fast{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dff(unsigned long long v) -> decimal32_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dff(unsigned long long v) -> decimal32_fast
 {
     return decimal32_fast{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DD(const char* str) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DD(const char* str) -> decimal64
 {
     decimal64 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dd(const char* str) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dd(const char* str) -> decimal64
 {
     decimal64 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DD(const char* str, std::size_t) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DD(const char* str, std::size_t) -> decimal64
 {
     decimal64 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dd(const char* str, std::size_t) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dd(const char* str, std::size_t) -> decimal64
 {
     decimal64 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DD(unsigned long long v) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DD(unsigned long long v) -> decimal64
 {
     return decimal64{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dd(unsigned long long v) -> decimal64
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dd(unsigned long long v) -> decimal64
 {
     return decimal64{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(const char* str) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DDF(const char* str) -> decimal64_fast
 {
     decimal64_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(const char* str) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_ddf(const char* str) -> decimal64_fast
 {
     decimal64_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(const char* str, std::size_t len) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DDF(const char* str, std::size_t len) -> decimal64_fast
 {
     decimal64_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(const char* str, std::size_t len) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_ddf(const char* str, std::size_t len) -> decimal64_fast
 {
     decimal64_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DDF(unsigned long long v) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DDF(unsigned long long v) -> decimal64_fast
 {
     return decimal64_fast{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _ddf(unsigned long long v) -> decimal64_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_ddf(unsigned long long v) -> decimal64_fast
 {
     return decimal64_fast{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DL(const char* str) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DL(const char* str) -> decimal128
 {
     decimal128 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dl(const char* str) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dl(const char* str) -> decimal128
 {
     decimal128 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DL(const char* str, std::size_t) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DL(const char* str, std::size_t) -> decimal128
 {
     decimal128 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dl(const char* str, std::size_t) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dl(const char* str, std::size_t) -> decimal128
 {
     decimal128 d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DL(unsigned long long v) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DL(unsigned long long v) -> decimal128
 {
     return decimal128{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dl(unsigned long long v) -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dl(unsigned long long v) -> decimal128
 {
     return decimal128{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(const char* str) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DLF(const char* str) -> decimal128_fast
 {
     decimal128_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(const char* str) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dlf(const char* str) -> decimal128_fast
 {
     decimal128_fast d;
     from_chars(str, str + detail::strlen(str), d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(const char* str, std::size_t len) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DLF(const char* str, std::size_t len) -> decimal128_fast
 {
     decimal128_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(const char* str, std::size_t len) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dlf(const char* str, std::size_t len) -> decimal128_fast
 {
     decimal128_fast d;
     from_chars(str, str + len, d);
     return d;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _DLF(unsigned long long v) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_DLF(unsigned long long v) -> decimal128_fast
 {
     return decimal128_fast{v};
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto operator  "" _dlf(unsigned long long v) -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto operator ""_dlf(unsigned long long v) -> decimal128_fast
 {
     return decimal128_fast{v};
 }


### PR DESCRIPTION
Warning was emitted by Clang-20 