### PR TITLE
Fix macro naming for format

### DIFF
--- a/examples/format.cpp
+++ b/examples/format.cpp
@@ -11,7 +11,7 @@
 #include <boost/decimal.hpp>
 #include <iostream>
 
-#ifdef BOOST_CRYPT_HAS_FORMAT_SUPPORT
+#ifdef BOOST_DECIMAL_HAS_FORMAT_SUPPORT
 
 #include <format>
 

--- a/include/boost/decimal/format.hpp
+++ b/include/boost/decimal/format.hpp
@@ -9,7 +9,7 @@
 #if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && !defined(BOOST_DECIMAL_DISABLE_CLIB) && \
     ((defined(__GNUC__) && __GNUC__ >= 13) || (defined(__clang__) && __clang_major__ >= 18) || (defined(_MSC_VER) && _MSC_VER >= 1940))
 
-#define BOOST_CRYPT_HAS_FORMAT_SUPPORT
+#define BOOST_DECIMAL_HAS_FORMAT_SUPPORT
 
 #include <boost/decimal/charconv.hpp>
 #include <algorithm>

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -14,7 +14,7 @@
 
 using namespace boost::decimal;
 
-#ifdef BOOST_CRYPT_HAS_FORMAT_SUPPORT
+#ifdef BOOST_DECIMAL_HAS_FORMAT_SUPPORT
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
 void test_general()


### PR DESCRIPTION
Used the wrong library name to the right effect.