### PR TITLE
Make `uint128` public since we return in a few places to the user

### DIFF
--- a/include/boost/decimal/bid_conversion.hpp
+++ b/include/boost/decimal/bid_conversion.hpp
@@ -11,6 +11,7 @@
 #include <boost/decimal/decimal32_fast.hpp>
 #include <boost/decimal/decimal64_fast.hpp>
 #include <boost/decimal/decimal128_fast.hpp>
+#include <boost/decimal/uint128.hpp>
 #include <boost/decimal/detail/concepts.hpp>
 
 namespace boost {
@@ -67,12 +68,12 @@ BOOST_DECIMAL_EXPORT constexpr auto from_bid_d64f(std::uint64_t bits) noexcept -
     return val;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto to_bid_d128(decimal128 val) noexcept -> detail::uint128
+BOOST_DECIMAL_EXPORT constexpr auto to_bid_d128(decimal128 val) noexcept -> uint128
 {
     return val.bits_;
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto from_bid_d128(detail::uint128 bits) noexcept -> decimal128
+BOOST_DECIMAL_EXPORT constexpr auto from_bid_d128(uint128 bits) noexcept -> decimal128
 {
     return from_bits(bits);
 }
@@ -84,13 +85,13 @@ BOOST_DECIMAL_EXPORT constexpr auto from_bid_d128(detail::uint128_t bits) noexce
 }
 #endif
 
-BOOST_DECIMAL_EXPORT constexpr auto to_bid_d128f(decimal128_fast val) noexcept -> detail::uint128
+BOOST_DECIMAL_EXPORT constexpr auto to_bid_d128f(decimal128_fast val) noexcept -> uint128
 {
     const decimal128 compliant_val {val};
     return to_bid_d128(compliant_val);
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto from_bid_d128f(detail::uint128 bits) noexcept -> decimal128_fast
+BOOST_DECIMAL_EXPORT constexpr auto from_bid_d128f(uint128 bits) noexcept -> decimal128_fast
 {
     const auto compliant_val {from_bid_d128(bits)};
     const decimal128_fast val {compliant_val};
@@ -126,12 +127,12 @@ BOOST_DECIMAL_EXPORT constexpr auto to_bid(decimal64_fast val) noexcept -> std::
     return to_bid_d64f(val);
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto to_bid(decimal128 val) noexcept -> detail::uint128
+BOOST_DECIMAL_EXPORT constexpr auto to_bid(decimal128 val) noexcept -> uint128
 {
     return to_bid_d128(val);
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto to_bid(decimal128_fast val) noexcept -> detail::uint128
+BOOST_DECIMAL_EXPORT constexpr auto to_bid(decimal128_fast val) noexcept -> uint128
 {
     return to_bid_d128f(val);
 }
@@ -169,14 +170,14 @@ constexpr auto from_bid<decimal64>(std::uint64_t bits) noexcept -> decimal64
 }
 
 BOOST_DECIMAL_EXPORT template <typename T = decimal128_fast>
-constexpr auto from_bid(detail::uint128 bits) noexcept
+constexpr auto from_bid(uint128 bits) noexcept
     BOOST_DECIMAL_REQUIRES(detail::is_decimal_floating_point_v, T)
 {
     return from_bid_d128f(bits);
 }
 
 BOOST_DECIMAL_EXPORT template <>
-constexpr auto from_bid<decimal128>(detail::uint128 bits) noexcept -> decimal128
+constexpr auto from_bid<decimal128>(uint128 bits) noexcept -> decimal128
 {
     return from_bid_d128(bits);
 }

--- a/include/boost/decimal/uint128.hpp
+++ b/include/boost/decimal/uint128.hpp
@@ -1,0 +1,18 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_UINT128_HPP
+#define BOOST_DECIMAL_UINT128_HPP
+
+#include <boost/decimal/detail/emulated128.hpp>
+
+namespace boost {
+namespace decimal {
+
+using uint128 = detail::uint128;
+
+} // namespace decimal
+} // namespace boost
+
+#endif // BOOST_DECIMAL_UINT128_HPP

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -188,3 +188,4 @@ compile compile_tests/iostream_compile.cpp ;
 compile compile_tests/literals_compile.cpp ;
 compile compile_tests/numbers_compile.cpp ;
 compile compile_tests/string_compile.cpp ;
+compile compile_tests/uint128.cpp ;

--- a/test/compile_tests/uint128.cpp
+++ b/test/compile_tests/uint128.cpp
@@ -1,0 +1,10 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal/bid_conversion.hpp>
+
+int main()
+{
+    return 0;
+}

--- a/test/test_big_uints.cpp
+++ b/test/test_big_uints.cpp
@@ -497,6 +497,7 @@ int main()
 
   test_digit_counting<boost::decimal::detail::uint128>();
   test_digit_counting<boost::decimal::detail::uint256_t>();
+  test_digit_counting<boost::decimal::uint128>();
 
   return boost::report_errors();
 }


### PR DESCRIPTION
Closes: #817 