### PR TITLE
Improve d128 mul

### DIFF
--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -133,22 +133,6 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE uint128 d128_small_combination_field_mask {UINT
                                                             UINT64_C(0)};
 BOOST_DECIMAL_CONSTEXPR_VARIABLE uint128 d128_big_combination_field_mask {UINT64_C(0b1'0000000000'0000000000'0000000000'0000000000'000000),
                                                           UINT64_C(0)};
-
-struct decimal128_components
-{
-    using significand_type = uint128;
-    using biased_exponent_type = std::int32_t;
-
-    significand_type sig {};
-    biased_exponent_type exp {};
-    bool sign {};
-
-    constexpr decimal128_components() = default;
-    constexpr decimal128_components(const decimal128_components& rhs) = default;
-    constexpr decimal128_components& operator=(const decimal128_components& rhs) = default;
-    constexpr decimal128_components(uint128 sig_, std::int32_t exp_, bool sign_) : sig{sig_}, exp{exp_}, sign{sign_} {}
-};
-
 } //namespace detail
 
 BOOST_DECIMAL_EXPORT class decimal128 final

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -38,16 +38,6 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE auto d128_fast_inf_high_bits = UINT64_MAX - 2;
 BOOST_DECIMAL_CONSTEXPR_VARIABLE auto d128_fast_qnan_high_bits = UINT64_MAX - 1;
 BOOST_DECIMAL_CONSTEXPR_VARIABLE auto d128_fast_snan_high_bits = UINT64_MAX;
 
-struct decimal128_fast_components
-{
-    using significand_type = uint128;
-    using biased_exponent_type = std::int_fast32_t;
-
-    significand_type sig;
-    biased_exponent_type exp;
-    bool sign;
-};
-
 } // namespace detail
 
 BOOST_DECIMAL_EXPORT class decimal128_fast final

--- a/include/boost/decimal/detail/components.hpp
+++ b/include/boost/decimal/detail/components.hpp
@@ -27,6 +27,11 @@ struct decimal_components
     biased_exponent_type exp;
     bool sign;
 
+    constexpr decimal_components() = default;
+    constexpr decimal_components(const decimal_components& rhs) = default;
+    constexpr decimal_components& operator=(const decimal_components& rhs) = default;
+    constexpr decimal_components(SigType sig_, BiasedExpType exp_, bool sign_) : sig{sig_}, exp{exp_}, sign{sign_} {}
+
     constexpr auto full_significand() const -> significand_type
     {
         return sig;
@@ -50,6 +55,8 @@ using decimal32_components = impl::decimal_components<std::uint32_t, std::int32_
 using decimal32_fast_components = impl::decimal_components<std::uint_fast32_t, std::int_fast32_t>;
 
 using decimal64_components = impl::decimal_components<std::uint64_t, std::int32_t>;
+
+using decimal128_components = impl::decimal_components<uint128, std::int32_t>;
 
 } // namespace detail
 } // namespace decimal

--- a/include/boost/decimal/detail/components.hpp
+++ b/include/boost/decimal/detail/components.hpp
@@ -23,9 +23,9 @@ struct decimal_components
     using significand_type = SigType;
     using biased_exponent_type = BiasedExpType;
 
-    significand_type sig;
-    biased_exponent_type exp;
-    bool sign;
+    significand_type sig {};
+    biased_exponent_type exp {};
+    bool sign {};
 
     constexpr decimal_components() = default;
     constexpr decimal_components(const decimal_components& rhs) = default;

--- a/include/boost/decimal/detail/components.hpp
+++ b/include/boost/decimal/detail/components.hpp
@@ -58,6 +58,8 @@ using decimal64_components = impl::decimal_components<std::uint64_t, std::int32_
 
 using decimal128_components = impl::decimal_components<uint128, std::int32_t>;
 
+using decimal128_fast_components = impl::decimal_components<uint128, std::int_fast32_t>;
+
 } // namespace detail
 } // namespace decimal
 } // namespace boost

--- a/include/boost/decimal/detail/mul_impl.hpp
+++ b/include/boost/decimal/detail/mul_impl.hpp
@@ -159,6 +159,49 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto d64_mul_impl(T lhs_sig, U lhs_exp, boo
     return {res_sig_64, res_exp, sign};
 }
 
+template <typename ReturnType, typename T>
+constexpr auto d128_mul_impl(const T& lhs, const T& rhs) noexcept -> ReturnType
+{
+    bool sign {lhs.isneg() != rhs.isneg()};
+
+    const auto lhs_sig {lhs.full_significand()};
+    const auto lhs_exp {lhs.biased_exponent()};
+    const auto rhs_sig {rhs.full_significand()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    const auto lhs_dig {detail::num_digits(lhs_sig)};
+    const auto rhs_dig {detail::num_digits(rhs_sig)};
+
+    const auto res_dig {lhs_dig + rhs_dig};
+
+    // If we can avoid it don't do 256 bit multiplication because it is slow
+    if (res_dig <= std::numeric_limits<uint128>::digits10)
+    {
+        auto res_sig {lhs_sig * rhs_sig};
+        auto res_exp {lhs_exp + rhs_exp};
+        return {res_sig, res_exp, sign};
+    }
+    else
+    {
+        // Once we have the normalized significands and exponents all we have to do is
+        // multiply the significands and add the exponents
+        auto res_sig {detail::umul256(lhs_sig, rhs_sig)};
+        auto res_exp {lhs_exp + rhs_exp};
+
+        const auto sig_dig {res_sig > pow10<uint256_t>(res_dig) ? res_dig : res_dig - 1};
+
+        if (sig_dig > std::numeric_limits<detail::uint128>::digits10)
+        {
+            const auto digit_delta {sig_dig - std::numeric_limits<detail::uint128>::digits10};
+            res_sig /= detail::uint256_t(pow10(detail::uint128(digit_delta)));
+            res_exp += digit_delta;
+        }
+
+        BOOST_DECIMAL_ASSERT(res_sig.high == uint128(0, 0));
+        return {res_sig.low, res_exp, sign};
+    }
+}
+
 template <typename ReturnType, BOOST_DECIMAL_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL U1,
                                BOOST_DECIMAL_INTEGRAL T2, BOOST_DECIMAL_INTEGRAL U2>
 constexpr auto d128_mul_impl(T1 lhs_sig, U1 lhs_exp, bool lhs_sign,

--- a/include/boost/decimal/detail/mul_impl.hpp
+++ b/include/boost/decimal/detail/mul_impl.hpp
@@ -188,7 +188,7 @@ constexpr auto d128_mul_impl(const T& lhs, const T& rhs) noexcept -> ReturnType
         auto res_sig {detail::umul256(lhs_sig, rhs_sig)};
         auto res_exp {lhs_exp + rhs_exp};
 
-        const auto sig_dig {res_sig > pow10<uint256_t>(res_dig) ? res_dig : res_dig - 1};
+        const auto sig_dig {res_sig > pow10(static_cast<uint256_t>(static_cast<std::uint64_t>(res_dig))) ? res_dig : res_dig - 1};
 
         if (sig_dig > std::numeric_limits<detail::uint128>::digits10)
         {
@@ -238,6 +238,23 @@ constexpr auto d128_mul_impl(T1 lhs_sig, U1 lhs_exp, bool lhs_sign,
         BOOST_DECIMAL_ASSERT(res_sig.high == uint128(0, 0));
         return {res_sig.low, res_exp, sign};
     }
+}
+
+template <typename ReturnType, typename T>
+constexpr auto d128_fast_mul_impl(const T& lhs, const T& rhs) noexcept -> ReturnType
+{
+    bool sign {lhs.isneg() != rhs.isneg()};
+
+    // Once we have the normalized significands and exponents all we have to do is
+    // multiply the significands and add the exponents
+    auto res_sig {detail::umul256(lhs.full_significand(), rhs.full_significand())};
+    auto res_exp {lhs.biased_exponent() + rhs.biased_exponent() + 30};
+
+    constexpr auto ten_pow_30 {detail::pow10(static_cast<uint256_t>(30))};
+    res_sig /= ten_pow_30;
+
+    BOOST_DECIMAL_ASSERT(res_sig.high == uint128(0,0));
+    return {res_sig.low, res_exp, sign};
 }
 
 template <typename ReturnType, BOOST_DECIMAL_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL U1,


### PR DESCRIPTION
Allows the value to be passed by const ref since it will be far too large to pass on the registers. Instead of digit counting the resulting value we can apply a heuristic to get it close to correct (which is all we need).