### PR TITLE
Fix division near 0

### DIFF
--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -910,7 +910,15 @@ constexpr decimal128::decimal128(T1 coeff, T2 exp, bool sign) noexcept
         }
         else
         {
-            bits_ = detail::d128_comb_inf_mask;
+            if (exp < 0)
+            {
+                constexpr auto zero_bits {detail::uint128{UINT64_C(0x2208000000000000), UINT64_C(0)}};
+                bits_ = zero_bits;
+            }
+            else
+            {
+                bits_ = detail::d128_comb_inf_mask;
+            }
         }
     }
 }

--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -875,6 +875,8 @@ constexpr decimal128::decimal128(T1 coeff, T2 exp, bool sign) noexcept
     }
     else
     {
+        constexpr auto zero_bits {detail::uint128{UINT64_C(0x2208000000000000), UINT64_C(0)}};
+
         // The value is probably infinity
 
         // If we can offset some extra power in the coefficient try to do so
@@ -900,7 +902,7 @@ constexpr decimal128::decimal128(T1 coeff, T2 exp, bool sign) noexcept
             {
                 if (exp < 0)
                 {
-                    *this = decimal128(0, 0, isneg);
+                    bits_ = zero_bits;
                 }
                 else
                 {
@@ -912,7 +914,6 @@ constexpr decimal128::decimal128(T1 coeff, T2 exp, bool sign) noexcept
         {
             if (exp < 0)
             {
-                constexpr auto zero_bits {detail::uint128{UINT64_C(0x2208000000000000), UINT64_C(0)}};
                 bits_ = zero_bits;
             }
             else

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -2,6 +2,9 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#ifndef BOOST_DECIMAL_DECIMAL128_FAST_HPP
+#define BOOST_DECIMAL_DECIMAL128_FAST_HPP
+
 #include <boost/decimal/decimal128.hpp>
 #include <boost/decimal/detail/apply_sign.hpp>
 #include <boost/decimal/detail/type_traits.hpp>
@@ -21,9 +24,6 @@
 #include <cstdint>
 
 #endif
-
-#ifndef BOOST_DECIMAL_DECIMAL128_FAST_HPP
-#define BOOST_DECIMAL_DECIMAL128_FAST_HPP
 
 namespace boost {
 namespace decimal {

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -394,15 +394,22 @@ constexpr decimal128_fast::decimal128_fast(T1 coeff, T2 exp, bool sign) noexcept
         exp = 0;
     }
 
-    const auto biased_exp {static_cast<exponent_type>(exp + detail::bias_v<decimal128>)};
+    const auto biased_exp {exp + detail::bias_v<decimal128>};
 
     if (biased_exp > detail::max_biased_exp_v<decimal128>)
     {
         significand_ = detail::d128_fast_inf;
     }
+    else if (biased_exp >= 0)
+    {
+        exponent_ = static_cast<exponent_type>(biased_exp);
+    }
     else
     {
-        exponent_ = biased_exp;
+        // Flush denorms to zero
+        significand_ = static_cast<significand_type>(0);
+        exponent_ = static_cast<exponent_type>(0 + detail::bias_v<decimal128>);
+        sign_ = false;
     }
 }
 

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -745,6 +745,7 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
     }
     else
     {
+        constexpr auto zero_bits {UINT32_C(0x22500000)};
         // The value is probably infinity
 
         // If we can offset some extra power in the coefficient try to do so
@@ -770,7 +771,7 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
             {
                 if (exp < 0)
                 {
-                    *this = decimal32(0, 0, isneg);
+                    bits_ = zero_bits;
                 }
                 else
                 {
@@ -783,7 +784,6 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
             if (exp < 0)
             {
                 // Normalized zero
-                constexpr auto zero_bits {UINT32_C(0x22500000)};
                 bits_ = zero_bits;
             }
             else

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -780,7 +780,16 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
         }
         else
         {
-            bits_ = detail::d32_comb_inf_mask;
+            if (exp < 0)
+            {
+                // Normalized zero
+                constexpr auto zero_bits {UINT32_C(0x22500000)};
+                bits_ = zero_bits;
+            }
+            else
+            {
+                bits_ = detail::d32_comb_inf_mask;
+            }
         }
     }
 }

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -393,16 +393,23 @@ constexpr decimal32_fast::decimal32_fast(T1 coeff, T2 exp, bool sign) noexcept
         exp = 0;
     }
 
-    auto biased_exp {static_cast<std::uint_fast32_t>(exp + detail::bias)};
+    const auto biased_exp {exp + detail::bias};
 
     // Decimal32 exponent holds 8 bits
     if (biased_exp > detail::max_biased_exp_v<decimal32_fast>)
     {
         significand_ = detail::d32_fast_inf;
     }
-    else
+    else if (biased_exp >= 0)
     {
         exponent_ = static_cast<exponent_type>(biased_exp);
+    }
+    else
+    {
+        // Flush denorms to zero
+        significand_ = static_cast<significand_type>(0);
+        exponent_ = static_cast<exponent_type>(101);
+        sign_ = false;
     }
 }
 

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -773,7 +773,15 @@ constexpr decimal64::decimal64(T1 coeff, T2 exp, bool sign) noexcept
         }
         else
         {
-            bits_ = detail::d64_comb_inf_mask;
+            if (exp < 0)
+            {
+                constexpr auto zero_bits {UINT64_C(0x2238000000000000)};
+                bits_ = zero_bits;
+            }
+            else
+            {
+                bits_ = detail::d64_comb_inf_mask;
+            }
         }
     }
 }

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -738,6 +738,8 @@ constexpr decimal64::decimal64(T1 coeff, T2 exp, bool sign) noexcept
     }
     else
     {
+        constexpr auto zero_bits {UINT64_C(0x2238000000000000)};
+
         // The value is probably infinity
 
         // If we can offset some extra power in the coefficient try to do so
@@ -763,7 +765,7 @@ constexpr decimal64::decimal64(T1 coeff, T2 exp, bool sign) noexcept
             {
                 if (exp < 0)
                 {
-                    *this = decimal64(0, 0, isneg);
+                    bits_ = zero_bits;
                 }
                 else
                 {
@@ -775,7 +777,6 @@ constexpr decimal64::decimal64(T1 coeff, T2 exp, bool sign) noexcept
         {
             if (exp < 0)
             {
-                constexpr auto zero_bits {UINT64_C(0x2238000000000000)};
                 bits_ = zero_bits;
             }
             else

--- a/include/boost/decimal/decimal64_fast.hpp
+++ b/include/boost/decimal/decimal64_fast.hpp
@@ -405,15 +405,22 @@ constexpr decimal64_fast::decimal64_fast(T1 coeff, T2 exp, bool sign) noexcept
         exp = 0;
     }
 
-    const auto biased_exp {static_cast<std::uint_fast32_t>(exp + detail::bias_v<decimal64>)};
+    const auto biased_exp {exp + detail::bias_v<decimal64>};
 
     if (biased_exp > detail::max_biased_exp_v<decimal64>)
     {
         significand_ = detail::d64_fast_inf;
     }
-    else
+    else if (biased_exp >= 0)
     {
         exponent_ = static_cast<exponent_type>(biased_exp);
+    }
+    else
+    {
+        // Flush denorms to zero
+        significand_ = static_cast<significand_type>(0);
+        exponent_ = static_cast<exponent_type>(0 + detail::bias_v<decimal64>);
+        sign_ = false;
     }
 }
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -53,6 +53,7 @@ run github_issue_798.cpp ;
 run github_issue_799.cpp ;
 run github_issue_802.cpp ;
 run github_issue_805.cpp ;
+run github_issue_808.cpp ;
 run link_1.cpp link_2.cpp link_3.cpp ;
 run quick.cpp ;
 run random_decimal32_comp.cpp ;

--- a/test/github_issue_798.cpp
+++ b/test/github_issue_798.cpp
@@ -8,17 +8,25 @@
 #include <boost/decimal/detail/cmath/next.hpp>
 #include <iomanip>
 #include <limits>
+#include <random>
 
 template <typename T>
 void test_zero()
 {
-    constexpr T zero {0};
-    constexpr T one {1};
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<int> dist(1, 1);
+
+    const T zero {0};
+    const T one {dist(rng)};
 
     const auto next_after_zero {boost::decimal::nextafter(zero, one)};
 
     BOOST_TEST_GT(next_after_zero, zero);
     BOOST_TEST_LT(next_after_zero, zero + 2*std::numeric_limits<T>::min());
+
+    const auto two_next_after_zero {boost::decimal::nextafter(next_after_zero, one)};
+    BOOST_TEST_GT(two_next_after_zero, next_after_zero);
+    BOOST_TEST_LT(two_next_after_zero, zero + 3*std::numeric_limits<T>::min());
 }
 
 template <typename T>

--- a/test/github_issue_808.cpp
+++ b/test/github_issue_808.cpp
@@ -1,0 +1,27 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+using namespace boost::decimal;
+
+template <typename Dec>
+void tiny_div()
+{
+    constexpr Dec zero {0};
+
+    const auto tiny = std::numeric_limits<Dec>::denorm_min();
+    const auto tiny2 = tiny / Dec{10};
+    BOOST_TEST(tiny2 == zero);
+}
+
+int main()
+{
+    tiny_div<decimal32>();
+    tiny_div<decimal64>();
+    tiny_div<decimal128>();
+
+    return boost::report_errors();
+}

--- a/test/github_issue_808.cpp
+++ b/test/github_issue_808.cpp
@@ -23,5 +23,9 @@ int main()
     tiny_div<decimal64>();
     tiny_div<decimal128>();
 
+    tiny_div<decimal32_fast>();
+    tiny_div<decimal64_fast>();
+    tiny_div<decimal128_fast>();
+
     return boost::report_errors();
 }


### PR DESCRIPTION
The values were often and incorrectly being set to infinity instead of zero. Also fixes the include guard for decimal128_fast since the IDE warned me about it.

Closes: #808 