### PR TITLE
Add additional constraints to the constructors

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -194,7 +194,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
     linux_pipeline(
         "Linux 22.04 GCC 12 64 ASAN",
         "cppalliance/droneubuntu2204:1",
-        { TOOLSET: 'gcc', COMPILER: 'g++-12', CXXSTD: '03,11,14,17,20,2b', ADDRMD: '64' } + asan,
+        { TOOLSET: 'gcc', COMPILER: 'g++-12', CXXSTD: '14,20', ADDRMD: '64' } + asan,
         "g++-12-multilib",
     ),
     

--- a/examples/adl.cpp
+++ b/examples/adl.cpp
@@ -31,9 +31,9 @@ int main()
     test(-0.5);
     test(-0.5L);
 
-    test(boost::decimal::decimal32{5, -1, true});
-    test(boost::decimal::decimal64{5, -1, true});
-    test(boost::decimal::decimal128{5, -1, true});
+    test(boost::decimal::decimal32{-5, -1});
+    test(boost::decimal::decimal64{-5, -1});
+    test(boost::decimal::decimal128{-5, -1});
 
     return error_counter;
 }

--- a/examples/basic_construction.cpp
+++ b/examples/basic_construction.cpp
@@ -11,8 +11,8 @@ int main()
     using namespace boost::decimal;
 
     constexpr decimal32 val_1 {100};         // Construction from an integer
-    constexpr decimal32 val_2 {10, 1};       // Construction from an integer and exponent
-    constexpr decimal32 val_3 {1, 2, false}; // Construction from an integer, exponent, and sign
+    constexpr decimal32 val_2 {10, 1};       // Construction from a signed integer and exponent
+    constexpr decimal32 val_3 {1U, 2, false}; // Construction from an unsigned integer, exponent, and sign
 
     std::cout << "Val_1: " << val_1 << '\n'
               << "Val_2: " << val_2 << '\n'

--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -240,7 +240,7 @@ public:
     #endif
     constexpr decimal128(T1 coeff, T2 exp) noexcept;
 
-    constexpr decimal128(bool value) noexcept;
+    explicit constexpr decimal128(bool value) noexcept;
 
     // 3.2.4.4 Conversion to integral type
     explicit constexpr operator bool() const noexcept;

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -617,7 +617,7 @@ constexpr decimal32::decimal32(T1 coeff, T2 exp, bool sign) noexcept // NOLINT(r
         }
     }
 
-    auto reduced_coeff {static_cast<std::uint32_t>(coeff)};
+    auto reduced_coeff {static_cast<significand_type>(coeff)};
     bool big_combination {false};
 
     if (reduced_coeff == 0U)
@@ -667,7 +667,7 @@ constexpr decimal32::decimal32(T1 coeff, T2 exp, bool sign) noexcept // NOLINT(r
         if (digit_delta > 0 && coeff_digits + digit_delta <= detail::precision)
         {
             exp -= digit_delta;
-            reduced_coeff *= detail::pow10(static_cast<T1>(digit_delta));
+            reduced_coeff *= detail::pow10(static_cast<significand_type>(digit_delta));
             *this = decimal32(reduced_coeff, exp, sign);
         }
         else

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -1311,12 +1311,29 @@ constexpr auto decimal32::full_significand() const noexcept -> significand_type
     return significand;
 }
 
+#ifdef _MSC_VER
+#  pragma warning(push)
+#  pragma warning(disable : 4127)
+#endif
+
 template <typename T>
 constexpr auto decimal32::edit_significand(T sig) noexcept
     BOOST_DECIMAL_REQUIRES_RETURN(detail::is_integral_v, T, void)
 {
-    *this = decimal32(sig, this->biased_exponent(), this->isneg());
+    const auto unsigned_sig {detail::make_positive_unsigned(sig)};
+    BOOST_DECIMAL_IF_CONSTEXPR (detail::is_signed_v<T>)
+    {
+        *this = decimal32(unsigned_sig, this->biased_exponent(), this->isneg() || sig < 0);
+    }
+    else
+    {
+        *this = decimal32(unsigned_sig, this->biased_exponent(), this->isneg());
+    }
 }
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
 
 constexpr auto decimal32::isneg() const noexcept -> bool
 {

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -263,6 +263,8 @@ public:
     #endif
     constexpr decimal32(T1 coeff, T2 exp) noexcept;
 
+    constexpr decimal32(bool value) noexcept;
+
     constexpr decimal32(const decimal32& val) noexcept = default;
     constexpr decimal32(decimal32&& val) noexcept = default;
     constexpr auto operator=(const decimal32& val) noexcept -> decimal32& = default;
@@ -685,6 +687,8 @@ constexpr decimal32::decimal32(T1 coeff, T2 exp) noexcept : decimal32(detail::ma
 #if defined(__GNUC__) && __GNUC__ >= 6
 #  pragma GCC diagnostic pop
 #endif
+
+constexpr decimal32::decimal32(bool value) noexcept : decimal32(static_cast<significand_type>(value), 0, false) {}
 
 constexpr auto from_bits(std::uint32_t bits) noexcept -> decimal32
 {

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -263,7 +263,7 @@ public:
     #endif
     constexpr decimal32(T1 coeff, T2 exp) noexcept;
 
-    constexpr decimal32(bool value) noexcept;
+    explicit constexpr decimal32(bool value) noexcept;
 
     constexpr decimal32(const decimal32& val) noexcept = default;
     constexpr decimal32(decimal32&& val) noexcept = default;

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -250,11 +250,18 @@ public:
 
     // 3.2.5 initialization from coefficient and exponent:
     #ifdef BOOST_DECIMAL_HAS_CONCEPTS
-    template <BOOST_DECIMAL_INTEGRAL T, BOOST_DECIMAL_INTEGRAL T2>
+    template <BOOST_DECIMAL_UNSIGNED_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL T2>
     #else
-    template <typename T, typename T2, std::enable_if_t<detail::is_integral_v<T> && detail::is_integral_v<T2>, bool> = true>
+    template <typename T1, typename T2, std::enable_if_t<detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool> = true>
     #endif
-    constexpr decimal32(T coeff, T2 exp, bool sign = false) noexcept;
+    constexpr decimal32(T1 coeff, T2 exp, bool sign = false) noexcept;
+
+    #ifdef BOOST_DECIMAL_HAS_CONCEPTS
+    template <BOOST_DECIMAL_SIGNED_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL T2>
+    #else
+    template <typename T1, typename T2, std::enable_if_t<!detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool> = true>
+    #endif
+    constexpr decimal32(T1 coeff, T2 exp) noexcept;
 
     constexpr decimal32(const decimal32& val) noexcept = default;
     constexpr decimal32(decimal32&& val) noexcept = default;
@@ -566,79 +573,49 @@ private:
 #endif
 
 #ifdef BOOST_DECIMAL_HAS_CONCEPTS
-template <BOOST_DECIMAL_INTEGRAL T, BOOST_DECIMAL_INTEGRAL T2>
+template <BOOST_DECIMAL_UNSIGNED_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL T2>
 #else
-template <typename T, typename T2, std::enable_if_t<detail::is_integral_v<T> && detail::is_integral_v<T2>, bool>>
+template <typename T1, typename T2, std::enable_if_t<detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool>>
 #endif
-constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(readability-function-cognitive-complexity,misc-no-recursion)
+constexpr decimal32::decimal32(T1 coeff, T2 exp, bool sign) noexcept // NOLINT(readability-function-cognitive-complexity,misc-no-recursion)
 {
-    using Unsigned_Integer = detail::make_unsigned_t<T>;
-
-    static_assert(detail::is_integral_v<T>, "Coefficient must be an integer");
+    static_assert(detail::is_integral_v<T1>, "Coefficient must be an integer");
     static_assert(detail::is_integral_v<T2>, "Exponent must be an integer");
 
-    bits_ = UINT32_C(0);
-    bool isneg {false};
-    Unsigned_Integer unsigned_coeff {detail::make_positive_unsigned(coeff)};
-    BOOST_DECIMAL_IF_CONSTEXPR (detail::is_signed_v<T>)
-    {
-        // This branch will never be taken by bool but it throws a warning prior to C++17
-        #ifdef _MSC_VER
-        #  pragma warning(push)
-        #  pragma warning(disable : 4804)
-        #endif
-
-        if (coeff < T{0} || sign)
-        {
-            bits_ = detail::d32_sign_mask;
-            isneg = true;
-        }
-
-        #ifdef _MSC_VER
-        #  pragma warning(pop)
-        #endif
-    }
-    else
-    {
-        if (sign)
-        {
-            bits_ = detail::d32_sign_mask;
-            isneg = true;
-        }
-    }
+    bits_ = sign ? detail::d32_sign_mask : UINT32_C(0);
 
     // If the coeff is not in range make it so
     // Only count the number of digits if we absolutely have to
-    int unsigned_coeff_digits {-1};
-    if (unsigned_coeff > detail::d32_max_significand_value)
+    int coeff_digits {-1};
+    if (coeff > detail::d32_max_significand_value)
     {
         // Since we know that the unsigned coeff is >= 10'000'000 we can use this information to traverse pruned trees
-        unsigned_coeff_digits = detail::d32_constructor_num_digits(unsigned_coeff);
-        if (unsigned_coeff_digits > detail::precision + 1)
+        coeff_digits = detail::d32_constructor_num_digits(coeff);
+        if (coeff_digits > detail::precision + 1)
         {
-            const auto digits_to_remove {unsigned_coeff_digits - (detail::precision + 1)};
+            const auto digits_to_remove {coeff_digits - (detail::precision + 1)};
 
             #if defined(__GNUC__) && !defined(__clang__)
             #  pragma GCC diagnostic push
             #  pragma GCC diagnostic ignored "-Wconversion"
             #endif
 
-            unsigned_coeff /= detail::pow10(static_cast<Unsigned_Integer>(digits_to_remove));
+            coeff /= detail::pow10(static_cast<T1>(digits_to_remove));
 
             #if defined(__GNUC__) && !defined(__clang__)
             #  pragma GCC diagnostic pop
             #endif
 
-            unsigned_coeff_digits -= digits_to_remove;
-            exp += static_cast<T2>(detail::fenv_round(unsigned_coeff, isneg)) + digits_to_remove;
+            coeff_digits -= digits_to_remove;
+            exp += static_cast<T2>(detail::fenv_round(coeff, sign)) + digits_to_remove;
         }
         else
         {
-            exp += static_cast<T2>(detail::fenv_round(unsigned_coeff, isneg));
+            exp += static_cast<T2>(detail::fenv_round(coeff, sign));
         }
     }
 
-    auto reduced_coeff {static_cast<std::uint32_t>(unsigned_coeff)};
+    auto reduced_coeff {static_cast<std::uint32_t>(coeff)};
     bool big_combination {false};
 
     if (reduced_coeff == 0U)
@@ -678,18 +655,18 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
         // If we can fit the extra exponent in the significand then we can construct the value
         // If we can't the value is either 0 or infinity depending on the sign of exp
 
-        if (unsigned_coeff_digits == -1)
+        if (coeff_digits == -1)
         {
-            unsigned_coeff_digits = detail::num_digits(unsigned_coeff);
+            coeff_digits = detail::num_digits(reduced_coeff);
         }
 
         const auto exp_delta {biased_exp - detail::d32_max_biased_exponent};
-        const auto digit_delta {unsigned_coeff_digits - static_cast<int>(exp_delta)};
-        if (digit_delta > 0 && unsigned_coeff_digits + digit_delta <= detail::precision)
+        const auto digit_delta {coeff_digits - static_cast<int>(exp_delta)};
+        if (digit_delta > 0 && coeff_digits + digit_delta <= detail::precision)
         {
             exp -= digit_delta;
-            unsigned_coeff *= detail::pow10(static_cast<Unsigned_Integer>(digit_delta));
-            *this = decimal32(unsigned_coeff, exp, isneg);
+            reduced_coeff *= detail::pow10(static_cast<T1>(digit_delta));
+            *this = decimal32(reduced_coeff, exp, sign);
         }
         else
         {
@@ -697,6 +674,13 @@ constexpr decimal32::decimal32(T coeff, T2 exp, bool sign) noexcept // NOLINT(re
         }
     }
 }
+
+#ifdef BOOST_DECIMAL_HAS_CONCEPTS
+template <BOOST_DECIMAL_SIGNED_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL T2>
+#else
+template <typename T1, typename T2, std::enable_if_t<!detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool>>
+#endif
+constexpr decimal32::decimal32(T1 coeff, T2 exp) noexcept : decimal32(detail::make_positive_unsigned(coeff), exp, coeff < 0) {}
 
 #if defined(__GNUC__) && __GNUC__ >= 6
 #  pragma GCC diagnostic pop

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -373,12 +373,16 @@ public:
 template <typename T1, typename T2, std::enable_if_t<detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool>>
 constexpr decimal32_fast::decimal32_fast(T1 coeff, T2 exp, bool sign) noexcept
 {
+    using minimum_coefficient_size = std::conditional_t<(sizeof(T1) > sizeof(significand_type)), T1, significand_type>;
+
+    minimum_coefficient_size min_coeff {coeff};
+
     sign_ = sign;
 
     // Normalize in the constructor, so we never have to worry about it again
-    detail::normalize<decimal32>(coeff, exp, sign);
+    detail::normalize<decimal32>(min_coeff, exp, sign);
 
-    significand_ = static_cast<significand_type>(coeff);
+    significand_ = static_cast<significand_type>(min_coeff);
 
     const auto biased_exp {significand_ == 0U ? 0 : exp + detail::bias};
 

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -293,7 +293,7 @@ public:
     #endif
     constexpr decimal64(T1 coeff, T2 exp) noexcept;
 
-    constexpr decimal64(bool value) noexcept;
+    explicit constexpr decimal64(bool value) noexcept;
 
     // cmath functions that are easier as friends
     friend constexpr auto signbit     BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (decimal64 rhs) noexcept -> bool;

--- a/include/boost/decimal/detail/cmath/acos.hpp
+++ b/include/boost/decimal/detail/cmath/acos.hpp
@@ -46,7 +46,7 @@ constexpr auto acos_impl(T x) noexcept
     {
         result = std::numeric_limits<T>::quiet_NaN();
     }
-    else if (x < T{5, -1, true})
+    else if (x < T{-5, -1})
     {
         result = numbers::pi_v<T> - 2 * detail::asin_series(sqrt((1 - absx) / 2));
     }

--- a/include/boost/decimal/detail/cmath/erf.hpp
+++ b/include/boost/decimal/detail/cmath/erf.hpp
@@ -110,7 +110,7 @@ constexpr auto erf_calc_impl(T z, bool invert) noexcept -> T
         {
             return -erf_calc_impl(-z, invert);
         }
-        else if (z < T{5, -1, true})
+        else if (z < T{-5, -1})
         {
             return 2 - erf_calc_impl(-z, invert);
         }

--- a/include/boost/decimal/detail/cmath/floor.hpp
+++ b/include/boost/decimal/detail/cmath/floor.hpp
@@ -30,7 +30,7 @@ constexpr auto floor BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
     using DivType = typename T::significand_type;
 
     constexpr T zero {0, 0};
-    constexpr T neg_one {1, 0, true};
+    constexpr T neg_one {1U, 0, true};
     const auto fp {fpclassify(val)};
 
     switch (fp)
@@ -66,7 +66,7 @@ constexpr auto floor BOOST_DECIMAL_PREVENT_MACRO_SUBSTITUTION (T val) noexcept
     }
     else
     {
-        decimal_digits--;
+        --decimal_digits;
     }
 
     new_sig /= detail::pow10<DivType>(decimal_digits);

--- a/include/boost/decimal/detail/cmath/riemann_zeta.hpp
+++ b/include/boost/decimal/detail/cmath/riemann_zeta.hpp
@@ -42,7 +42,7 @@ constexpr auto riemann_zeta_impl(T x) noexcept
     {
         // The value of riemann_zeta(0) is 1/2.
 
-        result = T { 5, -1, true };
+        result = T { 5U, -1, true };
     }
     #ifndef BOOST_DECIMAL_FAST_MATH
     else if (fpc != FP_NORMAL)

--- a/include/boost/decimal/detail/concepts.hpp
+++ b/include/boost/decimal/detail/concepts.hpp
@@ -117,10 +117,10 @@ template <typename T>
 concept integral = boost::decimal::detail::is_integral_v<T>;
 
 template <typename T>
-concept signed_integral = integral<T> && std::is_signed_v<T>;
+concept signed_integral = integral<T> && boost::decimal::detail::is_signed_v<T>;
 
 template <typename T>
-concept unsigned_integral = integral<T> && std::is_unsigned_v<T>;
+concept unsigned_integral = integral<T> && boost::decimal::detail::is_unsigned_v<T>;
 
 template <typename T>
 concept real = boost::decimal::detail::is_floating_point_v<T>;

--- a/test/random_decimal128_comp.cpp
+++ b/test/random_decimal128_comp.cpp
@@ -576,8 +576,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal128{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal128{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal128{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal128{0U, 0, true};
     BOOST_TEST(pos_zero == neg_zero);
 
     return boost::report_errors();

--- a/test/random_decimal128_fast_comp.cpp
+++ b/test/random_decimal128_fast_comp.cpp
@@ -595,8 +595,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal128_fast{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal128_fast{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal128_fast{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal128_fast{0U, 0, true};
     BOOST_TEST_EQ(pos_zero, neg_zero);
 
     return boost::report_errors();

--- a/test/random_decimal32_comp.cpp
+++ b/test/random_decimal32_comp.cpp
@@ -610,8 +610,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal32{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal32{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal32{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal32{0U, 0, true};
     BOOST_TEST_EQ(pos_zero, neg_zero);
 
     return boost::report_errors();

--- a/test/random_decimal32_fast_comp.cpp
+++ b/test/random_decimal32_fast_comp.cpp
@@ -607,8 +607,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal32_fast{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal32_fast{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal32_fast{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal32_fast{0U, 0, true};
     BOOST_TEST_EQ(pos_zero, neg_zero);
 
     return boost::report_errors();

--- a/test/random_decimal64_comp.cpp
+++ b/test/random_decimal64_comp.cpp
@@ -574,8 +574,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal64{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal64{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal64{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal64{0U, 0, true};
     BOOST_TEST_EQ(pos_zero, neg_zero);
 
     return boost::report_errors();

--- a/test/random_decimal64_fast_comp.cpp
+++ b/test/random_decimal64_fast_comp.cpp
@@ -597,8 +597,8 @@ int main()
     random_mixed_SPACESHIP(std::numeric_limits<unsigned long long>::min(), std::numeric_limits<unsigned long long>::max());
     #endif
 
-    constexpr auto pos_zero = boost::decimal::decimal64_fast{0, 0, false};
-    constexpr auto neg_zero = boost::decimal::decimal64_fast{0, 0, true};
+    constexpr auto pos_zero = boost::decimal::decimal64_fast{0U, 0, false};
+    constexpr auto neg_zero = boost::decimal::decimal64_fast{0U, 0, true};
     BOOST_TEST_EQ(pos_zero, neg_zero);
 
     return boost::report_errors();

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -790,7 +790,7 @@ void test_rint()
     BOOST_TEST(isnan(rint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(rint(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, true));
+    BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0U, 0, true));
 }
 
 template <typename Dec>
@@ -980,7 +980,7 @@ void test_nearbyint()
     BOOST_TEST(isnan(nearbyint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(nearbyint(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, true));
+    BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0U, 0, true));
 }
 
 template <typename Dec>
@@ -1022,7 +1022,7 @@ void test_round()
     BOOST_TEST(isnan(round(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(round(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, false));
+    BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0U, 0, false));
 }
 
 template <typename Dec>

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -396,8 +396,8 @@ void test_fma()
         // LCOV_EXCL_STOP
     }
 
-    BOOST_TEST_EQ(Dec(1, 0) + Dec(1, 0, true), Dec(0, 0));
-    BOOST_TEST_EQ(fma(Dec(1, -1), Dec(1, 1), Dec(1, 0, true)), Dec(0, 0));
+    BOOST_TEST_EQ(Dec(1, 0) + Dec(-1, 0), Dec(0, 0));
+    BOOST_TEST_EQ(fma(Dec(1, -1), Dec(1, 1), Dec(-1, 0)), Dec(0, 0));
 
     std::uniform_real_distribution<double> dist(-1e3, 1e3);
 
@@ -790,7 +790,7 @@ void test_rint()
     BOOST_TEST(isnan(rint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(rint(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), Dec(0, 0, true));
+    BOOST_TEST_EQ(rint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, true));
 }
 
 template <typename Dec>
@@ -873,7 +873,7 @@ void test_lrint()
     BOOST_TEST_EQ(lrint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng))), LONG_MIN);
     BOOST_TEST_EQ(lrint(Dec(0) * Dec(dist(rng))), 0);
     BOOST_TEST_EQ(lrint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), 0);
-    BOOST_TEST_EQ(lrint(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), 0);
+    BOOST_TEST_EQ(lrint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), 0);
 }
 
 template <typename Dec>
@@ -916,7 +916,7 @@ void test_llrint()
     BOOST_TEST_EQ(llrint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng))), LLONG_MIN);
     BOOST_TEST_EQ(llrint(Dec(0) * Dec(dist(rng))), 0);
     BOOST_TEST_EQ(llrint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), 0);
-    BOOST_TEST_EQ(llrint(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), 0);
+    BOOST_TEST_EQ(llrint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), 0);
 }
 
 template <typename Dec>
@@ -980,7 +980,7 @@ void test_nearbyint()
     BOOST_TEST(isnan(nearbyint(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(nearbyint(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), Dec(0, 0, true));
+    BOOST_TEST_EQ(nearbyint(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, true));
 }
 
 template <typename Dec>
@@ -1022,7 +1022,7 @@ void test_round()
     BOOST_TEST(isnan(round(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng)))));
     BOOST_TEST_EQ(abs(round(Dec(0) * Dec(dist(rng)))), Dec(0));
     BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), Dec(0));
-    BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), Dec(0, 0, false));
+    BOOST_TEST_EQ(round(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), Dec(0, 0, false));
 }
 
 template <typename Dec>
@@ -1065,7 +1065,7 @@ void test_lround()
     BOOST_TEST_EQ(lround(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng))), LONG_MIN);
     BOOST_TEST_EQ(lround(Dec(0) * Dec(dist(rng))), 0);
     BOOST_TEST_EQ(lround(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), 0);
-    BOOST_TEST_EQ(lround(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), 0);
+    BOOST_TEST_EQ(lround(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), 0);
 }
 
 template <typename Dec>
@@ -1108,7 +1108,7 @@ void test_llround()
     BOOST_TEST_EQ(llround(std::numeric_limits<Dec>::quiet_NaN() * Dec(dist(rng))), LLONG_MIN);
     BOOST_TEST_EQ(llround(Dec(0) * Dec(dist(rng))), 0);
     BOOST_TEST_EQ(llround(Dec(0) * Dec(dist(rng)) + Dec(1, -20)), 0);
-    BOOST_TEST_EQ(llround(Dec(0) * Dec(dist(rng)) + Dec(1, -20, true)), 0);
+    BOOST_TEST_EQ(llround(Dec(0) * Dec(dist(rng)) + Dec(1U, -20, true)), 0);
 }
 
 template <typename Dec>

--- a/test/test_decimal32_fast_basis.cpp
+++ b/test/test_decimal32_fast_basis.cpp
@@ -381,7 +381,7 @@ void test_construct_from_float()
     decimal32_fast float_frac(T(1.2345));
     BOOST_TEST_EQ(fraction, float_frac);
 
-    constexpr decimal32_fast neg_frac(98123, -4, true);
+    constexpr decimal32_fast neg_frac(-98123, -4);
     decimal32_fast neg_float_frac(T(-9.8123));
     BOOST_TEST_EQ(neg_frac, neg_float_frac);
 }

--- a/test/test_decimal64_fast_basis.cpp
+++ b/test/test_decimal64_fast_basis.cpp
@@ -357,7 +357,7 @@ void test_construct_from_float()
     decimal64_fast float_frac(T(1.2345));
     BOOST_TEST_EQ(fraction, float_frac);
 
-    constexpr decimal64_fast neg_frac(98123, -4, true);
+    constexpr decimal64_fast neg_frac(-98123, -4);
     decimal64_fast neg_float_frac(T(-9.8123));
     BOOST_TEST_EQ(neg_frac, neg_float_frac);
 }

--- a/test/test_float_conversion.cpp
+++ b/test/test_float_conversion.cpp
@@ -73,8 +73,8 @@ void test_compute_float64()
     BOOST_TEST_EQ(compute_float64(1000, 5U * dist(gen), false, success), HUGE_VAL);
     BOOST_TEST_EQ(compute_float64(1000, 5U * dist(gen), true, success), -HUGE_VAL);
     BOOST_TEST_EQ(compute_float64(-325, 5U * dist(gen), false, success), 0.0);
-    BOOST_TEST_EQ(compute_float64(static_cast<std::int64_t>(dist(gen)) * 50, 0, false, success), 0.0);
-    BOOST_TEST_EQ(compute_float64(static_cast<std::int64_t>(dist(gen)) * 50, 0, true, success), 0.0);
+    BOOST_TEST_EQ(compute_float64(static_cast<std::int64_t>(dist(gen)) * 50U, 0, false, success), 0.0);
+    BOOST_TEST_EQ(compute_float64(static_cast<std::int64_t>(dist(gen)) * 50U, 0, true, success), 0.0);
     BOOST_TEST_EQ(compute_float64(300, UINT64_MAX, false, success), 0.0 * static_cast<double>(dist(gen)));
 
     // Composite

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -56,18 +56,18 @@ void test_general()
 
     if constexpr (std::numeric_limits<T>::digits10 <= 7)
     {
-        BOOST_TEST_EQ(std::format("{:g}", T {21, 6, true}), "-2.1e+07");
-        BOOST_TEST_EQ(std::format("{:g}", T {211, 6, true}), "-2.11e+08");
-        BOOST_TEST_EQ(std::format("{:g}", T {2111, 6, true}), "-2.111e+09");
-        BOOST_TEST_EQ(std::format("{:G}", T {21, 6, true}), "-2.1E+07");
-        BOOST_TEST_EQ(std::format("{:G}", T {211, 6, true}), "-2.11E+08");
-        BOOST_TEST_EQ(std::format("{:G}", T {2111, 6, true}), "-2.111E+09");
+        BOOST_TEST_EQ(std::format("{:g}", T {-21, 6}), "-2.1e+07");
+        BOOST_TEST_EQ(std::format("{:g}", T {-211, 6}), "-2.11e+08");
+        BOOST_TEST_EQ(std::format("{:g}", T {-2111, 6}), "-2.111e+09");
+        BOOST_TEST_EQ(std::format("{:G}", T {-21, 6}), "-2.1E+07");
+        BOOST_TEST_EQ(std::format("{:G}", T {-211, 6}), "-2.11E+08");
+        BOOST_TEST_EQ(std::format("{:G}", T {-2111, 6}), "-2.111E+09");
     }
     else
     {
-        BOOST_TEST_EQ(std::format("{:g}", T {21, 6, true}), "-21000000");
-        BOOST_TEST_EQ(std::format("{:g}", T {211, 6, true}), "-211000000");
-        BOOST_TEST_EQ(std::format("{:g}", T {2111, 6, true}), "-2111000000");
+        BOOST_TEST_EQ(std::format("{:g}", T {-21, 6}), "-21000000");
+        BOOST_TEST_EQ(std::format("{:g}", T {-211, 6}), "-211000000");
+        BOOST_TEST_EQ(std::format("{:g}", T {-2111, 6}), "-2111000000");
     }
 
     BOOST_TEST_EQ(std::format("{:g}", std::numeric_limits<T>::infinity()), "inf");
@@ -88,17 +88,17 @@ void test_general()
 template <typename T>
 void test_fixed()
 {
-    BOOST_TEST_EQ(std::format("{:f}", T {21, 6, true}), "-21000000.000000");
-    BOOST_TEST_EQ(std::format("{:f}", T {211, 6, true}), "-211000000.000000");
-    BOOST_TEST_EQ(std::format("{:f}", T {2111, 6, true}), "-2111000000.000000");
+    BOOST_TEST_EQ(std::format("{:f}", T {-21, 6}), "-21000000.000000");
+    BOOST_TEST_EQ(std::format("{:f}", T {-211, 6}), "-211000000.000000");
+    BOOST_TEST_EQ(std::format("{:f}", T {-2111, 6}), "-2111000000.000000");
 
-    BOOST_TEST_EQ(std::format("{:.0f}", T {21, 6, true}), std::string{"-21000000"});
-    BOOST_TEST_EQ(std::format("{:.0f}", T {211, 6, true}), std::string{"-211000000"});
-    BOOST_TEST_EQ(std::format("{:.0f}", T {2111, 6, true}), std::string{"-2111000000"});
+    BOOST_TEST_EQ(std::format("{:.0f}", T {-21, 6}), std::string{"-21000000"});
+    BOOST_TEST_EQ(std::format("{:.0f}", T {-211, 6}), std::string{"-211000000"});
+    BOOST_TEST_EQ(std::format("{:.0f}", T {-2111, 6}), std::string{"-2111000000"});
 
-    BOOST_TEST_EQ(std::format("{:.1f}", T {21, 6, true}), std::string{"-21000000.0"});
-    BOOST_TEST_EQ(std::format("{:.1f}", T {211, 6, true}), std::string{"-211000000.0"});
-    BOOST_TEST_EQ(std::format("{:.1f}", T {2111, 6, true}), std::string{"-2111000000.0"});
+    BOOST_TEST_EQ(std::format("{:.1f}", T {-21, 6}), std::string{"-21000000.0"});
+    BOOST_TEST_EQ(std::format("{:.1f}", T {-211, 6}), std::string{"-211000000.0"});
+    BOOST_TEST_EQ(std::format("{:.1f}", T {-2111, 6}), std::string{"-2111000000.0"});
 
     BOOST_TEST_EQ(std::format("{:.0f}", T {0}), "0");
     BOOST_TEST_EQ(std::format("{:f}", std::numeric_limits<T>::infinity()), "inf");
@@ -119,13 +119,13 @@ void test_fixed()
 template <typename T>
 void test_scientific()
 {
-    BOOST_TEST_EQ(std::format("{:e}", T {21, 6, true}), "-2.100000e+07");
-    BOOST_TEST_EQ(std::format("{:e}", T {211, 6, true}), "-2.110000e+08");
-    BOOST_TEST_EQ(std::format("{:e}", T {2111, 6, true}), "-2.111000e+09");
+    BOOST_TEST_EQ(std::format("{:e}", T {-21, 6}), "-2.100000e+07");
+    BOOST_TEST_EQ(std::format("{:e}", T {-211, 6}), "-2.110000e+08");
+    BOOST_TEST_EQ(std::format("{:e}", T {-2111, 6}), "-2.111000e+09");
 
-    BOOST_TEST_EQ(std::format("{:E}", T {21, 6, true}), "-2.100000E+07");
-    BOOST_TEST_EQ(std::format("{:E}", T {211, 6, true}), "-2.110000E+08");
-    BOOST_TEST_EQ(std::format("{:E}", T {2111, 6, true}), "-2.111000E+09");
+    BOOST_TEST_EQ(std::format("{:E}", T {-21, 6}), "-2.100000E+07");
+    BOOST_TEST_EQ(std::format("{:E}", T {-211, 6}), "-2.110000E+08");
+    BOOST_TEST_EQ(std::format("{:E}", T {-2111, 6}), "-2.111000E+09");
 
     BOOST_TEST_EQ(std::format("{:.0E}", T {0}), "0E+00");
     BOOST_TEST_EQ(std::format("{:e}", std::numeric_limits<T>::infinity()), "inf");

--- a/test/test_git_issue_266.cpp
+++ b/test/test_git_issue_266.cpp
@@ -23,5 +23,9 @@ int main()
     test<decimal64>();
     test<decimal128>();
 
+    test<decimal32_fast>();
+    test<decimal64_fast>();
+    test<decimal128_fast>();
+
     return boost::report_errors();
 }

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -826,9 +826,9 @@ void test_434_hex()
 template <typename T>
 void test_777()
 {
-    constexpr T value1 = T {21, 6, true};
-    constexpr T value2 = T {211, 6, true};
-    constexpr T value3 = T {2111, 6, true};
+    constexpr T value1 = T {21U, 6, true};
+    constexpr T value2 = T {211U, 6, true};
+    constexpr T value3 = T {2111U, 6, true};
 
     test_value(value1, "-21000000", chars_format::fixed, 0);
     test_value(value2, "-211000000", chars_format::fixed, 0);

--- a/test/test_to_string.cpp
+++ b/test/test_to_string.cpp
@@ -23,9 +23,9 @@ void test()
     BOOST_TEST_EQ(to_string(T{10000}), "10000.000000");
     BOOST_TEST_EQ(to_string(T{210000}), "210000.000000");
     BOOST_TEST_EQ(to_string(T{2100000}), "2100000.000000");
-    BOOST_TEST_EQ(to_string(T{21, 6, true}), "-21000000.000000");
-    BOOST_TEST_EQ(to_string(T{211, 6, true}), "-211000000.000000");
-    BOOST_TEST_EQ(to_string(T{2111, 6, true}), "-2111000000.000000");
+    BOOST_TEST_EQ(to_string(T{21U, 6, true}), "-21000000.000000");
+    BOOST_TEST_EQ(to_string(T{211U, 6, true}), "-211000000.000000");
+    BOOST_TEST_EQ(to_string(T{2111U, 6, true}), "-2111000000.000000");
 
     BOOST_TEST_EQ(to_string(std::numeric_limits<T>::infinity()), "inf");
     BOOST_TEST_EQ(to_string(-std::numeric_limits<T>::infinity()), "-inf");


### PR DESCRIPTION
You can either pass a signed integer, or a sign but not both. Should make things easier to reason about

Closes: #837 