### PR TITLE
917 Part 1 (decimal32_fast)

### DIFF
--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -116,6 +116,9 @@ private:
     template <typename ReturnType, typename T>
     friend constexpr auto detail::d32_add_impl(const T& lhs, const T& rhs) noexcept -> ReturnType;
 
+    template <typename ReturnType, typename T>
+    friend constexpr auto detail::d32_fast_add_only_impl(const T& lhs, const T& rhs) noexcept -> ReturnType;
+
     template <BOOST_DECIMAL_FAST_DECIMAL_FLOATING_TYPE DecimalType>
     BOOST_DECIMAL_FORCE_INLINE friend constexpr auto fast_equality_impl(const DecimalType& lhs, const DecimalType& rhs) noexcept -> bool;
 

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -935,10 +935,10 @@ constexpr auto operator*(Integer lhs, decimal32_fast rhs) noexcept
 
 constexpr auto div_impl(decimal32_fast lhs, decimal32_fast rhs, decimal32_fast& q, decimal32_fast& r) noexcept -> void
 {
+    constexpr decimal32_fast zero {0, 0};
+    
     #ifndef BOOST_DECIMAL_FAST_MATH
     const bool sign {lhs.isneg() != rhs.isneg()};
-
-    constexpr decimal32_fast zero {0, 0};
     constexpr decimal32_fast nan {direct_init(detail::d32_fast_qnan, UINT8_C(0), false)};
     constexpr decimal32_fast inf {direct_init(detail::d32_fast_inf, UINT8_C(0), false)};
 

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -346,6 +346,7 @@ public:
     explicit constexpr operator Decimal() const noexcept;
 
     friend constexpr auto direct_init(std::uint_fast32_t significand, std::uint_fast8_t exponent, bool sign) noexcept -> decimal32_fast;
+    friend constexpr auto direct_init(const detail::decimal32_fast_components& x) noexcept -> decimal32_fast;
 
     // <cmath> or extensions that need to be friends
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
@@ -452,6 +453,16 @@ constexpr auto direct_init(std::uint_fast32_t significand, std::uint_fast8_t exp
     val.significand_ = significand;
     val.exponent_ = exponent;
     val.sign_ = sign;
+
+    return val;
+}
+
+constexpr auto direct_init(const detail::decimal32_fast_components& x) noexcept -> decimal32_fast
+{
+    decimal32_fast val;
+    val.significand_ = x.sig;
+    val.exponent_ = static_cast<std::uint_fast8_t>(static_cast<int>(x.exp) + detail::bias_v<decimal32_fast>);
+    val.sign_ = x.sign;
 
     return val;
 }

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -762,7 +762,15 @@ constexpr auto operator+(decimal32_fast lhs, decimal32_fast rhs) noexcept -> dec
     }
     #endif
 
-    return detail::d32_add_impl<decimal32_fast>(lhs, rhs);
+    if (lhs.isneg() || rhs.isneg())
+    {
+        return detail::d32_add_impl<decimal32_fast>(lhs, rhs);
+    }
+    else
+    {
+        const auto res {detail::d32_fast_add_only_impl<detail::decimal32_fast_components>(lhs, rhs)};
+        return direct_init(res);
+    }
 }
 
 template <typename Integer>

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -1007,7 +1007,15 @@ constexpr auto div_impl(decimal32_fast lhs, decimal32_fast rhs, decimal32_fast& 
     BOOST_DECIMAL_ASSERT(res_sig >= 1'000'000 || res_sig == 0U);
     BOOST_DECIMAL_ASSERT(res_exp <= 9'999'999 || res_sig == 0U);
 
-    q = direct_init(static_cast<typename decimal32_fast::significand_type>(res_sig), static_cast<typename decimal32_fast::exponent_type>(res_exp), isneg);
+    if (BOOST_DECIMAL_LIKELY(res_exp >= 0))
+    {
+        q = direct_init(static_cast<typename decimal32_fast::significand_type>(res_sig), static_cast<typename decimal32_fast::exponent_type>(res_exp), isneg);
+    }
+    else
+    {
+        // Flush to zero
+        q = zero;
+    }
 }
 
 constexpr auto mod_impl(decimal32_fast lhs, decimal32_fast rhs, const decimal32_fast& q, decimal32_fast& r) noexcept -> void

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -815,7 +815,15 @@ constexpr auto operator-(decimal32_fast lhs, decimal32_fast rhs) noexcept -> dec
 
     rhs.sign_ = !rhs.sign_;
 
-    return detail::d32_add_impl<decimal32_fast>(lhs, rhs);
+    if (lhs.sign_ || rhs.sign_)
+    {
+        return detail::d32_add_impl<decimal32_fast>(lhs, rhs);
+    }
+    else
+    {
+        const auto res {detail::d32_fast_add_only_impl<detail::decimal32_fast_components>(lhs, rhs)};
+        return direct_init(res);
+    }
 }
 
 template <typename Integer>

--- a/include/boost/decimal/detail/add_impl.hpp
+++ b/include/boost/decimal/detail/add_impl.hpp
@@ -126,8 +126,8 @@ constexpr auto d32_fast_add_only_impl(const T& lhs, const T& rhs) noexcept -> Re
         lhs_exp += detail::fenv_round(res_sig, false);
     }
 
-    BOOST_DECIMAL_ASSERT(res_sig >= 1'000'000);
-    BOOST_DECIMAL_ASSERT(res_sig <= max_non_normalized_value);
+    BOOST_DECIMAL_ASSERT(res_sig >= 1'000'000U || res_sig == 0U);
+    BOOST_DECIMAL_ASSERT(res_sig <= max_non_normalized_value || res_sig == 0U);
 
     return ReturnType{static_cast<typename ReturnType::significand_type>(res_sig), lhs_exp, false};
 }

--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-#define BOOST_INT128_ALLOW_SIGN_CONVERSION
+#define BOOST_DECIMAL_DETAIL_INT128_ALLOW_SIGN_CONVERSION
 
 #include <boost/decimal.hpp>
 #include <chrono>

--- a/test/random_decimal32_fast_math.cpp
+++ b/test/random_decimal32_fast_math.cpp
@@ -277,6 +277,28 @@ void random_multiplication(T lower, T upper)
 }
 
 template <typename T>
+void random_spot_multiplication(T val1, T val2)
+{
+    const decimal32_fast dec1 {val1};
+    const decimal32_fast dec2 {val2};
+
+    const decimal32_fast res {dec1 * dec2};
+    const decimal32_fast res_int {val1 * val2};
+
+    if (!BOOST_TEST_EQ(res, res_int))
+    {
+        // LCOV_EXCL_START
+        std::cerr << "Val 1: " << val1
+                  << "\nDec 1: " << dec1
+                  << "\nVal 2: " << val2
+                  << "\nDec 2: " << dec2
+                  << "\nDec res: " << res
+                  << "\nInt res: " << val1 * val2 << std::endl;
+        // LCOV_EXCL_STOP
+    }
+}
+
+template <typename T>
 void random_mixed_multiplication(T lower, T upper)
 {
     std::uniform_int_distribution<T> dist(lower, upper);
@@ -484,6 +506,11 @@ int main()
 
     // Positive values
     const auto sqrt_int_max = static_cast<int>(std::sqrt(static_cast<double>((std::numeric_limits<int>::max)())));
+
+    random_spot_multiplication(4477, 4139);
+    random_spot_multiplication(28270, 45750);
+    random_spot_multiplication(2137, 3272);
+    random_spot_multiplication(-26554, 22692);
 
     random_multiplication(0, 5'000);
     random_multiplication(0L, 5'000L);

--- a/test/random_decimal32_fast_math.cpp
+++ b/test/random_decimal32_fast_math.cpp
@@ -448,6 +448,31 @@ void random_mixed_division(T lower, T upper)
     BOOST_TEST(isinf(val1 / zero));
 }
 
+template <typename T>
+void random_spot_division(T val1, T val2)
+{
+    const decimal32_fast dec1 {val1};
+    const decimal32_fast dec2 {val2};
+
+    const decimal32_fast res {dec1 / dec2};
+    const decimal32_fast res_int {static_cast<float>(val1) / static_cast<float>(val2)};
+
+    if (isinf(res) && isinf(res_int))
+    {
+    }
+    else if (!BOOST_TEST(abs(res - res_int) < decimal32_fast(1, -2)))
+    {
+        // LCOV_EXCL_START
+        std::cerr << "Val 1: " << val1
+                  << "\nDec 1: " << dec1
+                  << "\nVal 2: " << val2
+                  << "\nDec 2: " << dec2
+                  << "\nDec res: " << res
+                  << "\nInt res: " << static_cast<float>(val1) / static_cast<float>(val2) << std::endl;
+        // LCOV_EXCL_STOP
+    }
+}
+
 int main()
 {
     // Values that won't exceed the range of the significand
@@ -540,6 +565,8 @@ int main()
     random_mixed_multiplication(-5'000L, 5'000L);
     random_mixed_multiplication(-5'000LL, 5'000LL);
     random_mixed_multiplication(-sqrt_int_max, sqrt_int_max);
+
+    random_spot_division(-23984, 2561);
 
     random_division(0, 5'000);
     random_division(0L, 5'000L);


### PR DESCRIPTION
This gives us order 30% speedup for addition, 35% for multiplication, 27% for division on decimal32_fast. Since we know or we can track the digit count of the resulting significand we can directly initialize a value, skipping the constructor entirely. 

These same techniques will be applied to decimal64_fast and decimal128_fast in subsequent PRs