### PR TITLE
Handle unclear code from local metal benching

### DIFF
--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -1000,12 +1000,16 @@ constexpr auto div_impl(decimal_fast32_t lhs, decimal_fast32_t rhs, decimal_fast
               << "\nexp rhs: " << exp_rhs << std::endl;
     #endif
 
+    using local_signed_exponent_type = std::common_type_t<std::int_fast32_t, int>;
+
+    static_assert(sizeof(local_signed_exponent_type) >= 4, "Error in local exponent type definition");
+
     // We promote to uint64 since the significands are currently 32-bits
     // By appending enough zeros to the LHS we end up finding what we need anyway
     constexpr auto ten_pow_precision {detail::pow10(static_cast<std::uint_fast64_t>(detail::precision_v<decimal32_t>))};
     const auto big_sig_lhs {static_cast<std::uint_fast64_t>(lhs.significand_) * ten_pow_precision};
     auto res_sig {big_sig_lhs / static_cast<std::uint_fast64_t>(rhs.significand_)};
-    auto res_exp {lhs.exponent_ - rhs.exponent_ + 94};
+    local_signed_exponent_type res_exp {static_cast<local_signed_exponent_type>(lhs.exponent_) - static_cast<local_signed_exponent_type>(rhs.exponent_) + 94};
     const auto isneg {lhs.sign_ != rhs.sign_};
 
     // If we have 8 figures round it down to 7

--- a/include/boost/decimal/detail/buffer_sizing.hpp
+++ b/include/boost/decimal/detail/buffer_sizing.hpp
@@ -23,11 +23,11 @@ namespace detail {
 #endif
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE Dec>
-constexpr int get_real_precision(int precision = -1) noexcept
+constexpr int get_real_precision(int my_precision = -1) noexcept
 {
     // If the user did not specify a precision than we use the maximum representable amount
     // and remove trailing zeros at the end
-    return precision == -1 ? std::numeric_limits<Dec>::max_digits10 : precision;
+    return my_precision == -1 ? std::numeric_limits<Dec>::max_digits10 : precision;
 }
 
 // We don't need to use the full digit counting since the range of the exponents is well defined


### PR DESCRIPTION
Hi Matt (@mborland) this PR handles some warnings that I believe pointed out some unclear code. I detected these when doing local bare-metal benchmarking of the newer, faster `decimal64_t`. I ran into some (I believe) legitimate warnings on the metal and handled them.

The results of the benchmark are excellent and `decimal64_t` is better than two-fold faster than last year.

The table number was $490{\mu}s$ last year and is now $200{\mu}s$.

These are the updated numbers from boost::decimal Git-hash 0b474bf05f339f21d87dd1902dc6294bb9914254.

| Type                           |  runtime ${\mu}s$ |  relative  |    code-size [kb] |
|--------------------------------|---------------|------------|-------------------|
| 64-bit `double` (built-in, no FPU)      |  $22$          |   $1.0$      |       $5.6$         |
| ::math::softfloat::float64_t   |   $27$          |   $1.2$      |       $8.5$         |
| boost::decimal::decimal64_t    |  $200$          |   $9.1$      |       $20$          |

```
#if 0
GCC14.2, arm-none-eabi, float-abi=soft, -O2

Calculation exp() via Pade approximation approx. 15 decimal digits.
Code-size includes about 2kb for startup, clock-init, skinny MCAL and cooperative time-scheduler.

target-specific flags
---------------------
-O2
-mcpu=cortex-m4
-mtune=cortex-m4
-mthumb
-mfloat-abi=soft
-finline-functions
-finline-limit=128
-mno-unaligned-access
-mno-long-calls
#endif
```
