### PR TITLE
Update Linux Benchmarks and Add Intel Benchmarks

### DIFF
--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -265,8 +265,6 @@ And on the same platform with GCC 13.3.0
 
 Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
 
-==== Addition
-
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
@@ -345,41 +343,83 @@ And on the same platform with GCC 13.3.0
 
 ==== Multiplication
 
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
+
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 53,469
-| 1.093
+| 78,445
+| 1.078
 | `double`
-| 48,903
+| 72,798
 | 1.000
 | `decimal32_t`
-| 1,993,989
-| 40.774
+| 1,735,239
+| 23.836
 | `decimal64_t`
-| 2,766,602
-| 56.573
+| 2,272,739
+| 31.220
 | `decimal128_t`
-| 4,796,346
-| 98.079
+| 6,396,750
+| 87.870
 | `decimal_fast32_t`
-| 1,117,727
-| 22.856
+| 993,256
+| 13.644
 | `decimal_fast64_t`
-| 1,369,834
-| 28.011
+| 1,670,141
+| 22.942
 | `decimal_fast128_t`
-| 8,139,518
-| 166.442
+| 5,959,977
+| 81.870
+| `Intel Decimal32`
+| 931,655
+| 12.798
+| `Intel Decimal64`
+| 963,464
+| 13.235
+// For unknown reasons this function segfaults
+//| `Intel Decimal128`
+//| 2,162,490
+//| 29.545
+|===
+
+And on the same platform with GCC 13.3.0
+
+|===
+| Type | Runtime (us) | Ratio to `double`
+| `float`
+| 76,238
+| 1.161
+| `double`
+| 65,652
+| 1.000
+| `decimal32_t`
+| 1,703,365
+| 25.945
+| `decimal64_t`
+| 2,564,605
+| 39.063
+| `decimal128_t`
+| 7,115,514
+| 108.382
+| `decimal_fast32_t`
+| 1,225,047
+| 18.660
+| `decimal_fast64_t`
+| 1,904,509
+| 29.009
+| `decimal_fast128_t`
+| 6,056,348
+| 92.249
 | GCC `_Decimal32`
-| 2,507,998
-| 51.285
+| 2,635,531
+| 40.144
 | GCC `_Decimal64`
-| 2,414,864
-| 49.381
+| 2,545,441
+| 38.772
 | GCC `_Decimal128`
-| 6,248,956
-| 127.783
+| 7,050,299
+| 107.289
 |===
 
 ==== Division

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -173,10 +173,6 @@ Run using a Macbook pro with M4 Max chipset running macOS Sequoia 15.5 and homeb
 The benchmark for these operations generates a random vector containing 20,000,000 elements and does operations `+`, `-`, `*`, `/` between `vec[i] and vec[i + 1]`.
 This is repeated 5 times to generate stable results.
 
-As discussed in the design of the fast types the significand is stored in normalized form so that we do not have to worry about the effects of cohorts.
-Unfortunately this means that `decimal_fast128_t` multiplication is always carried out internally at 256-bit size whereas `decimal128_t` contains heuristics in `operator*` to avoid 256-bit multiplication when it is not needed (i.e. the resultant significand is less than or equal to 128-bits).
-This causes multiplication of `decimal_fast128_t` to be ~1.72x slower than `decimal128_t`, but all other operators leave us with a geometric average runtime under 1.00 for `decimal_fast128_t` / `decimal128_t` so we accept this tradeoff.
-
 === x64 Linux Results
 
 Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -65,6 +65,9 @@ Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compi
 | `Intel Decimal64`
 | 2,386,409
 | 16.581
+| `Intel Decimal128`
+| 3,203,050
+| 22.255
 |===
 
 And on the same platform with GCC 13.3.0
@@ -178,45 +181,84 @@ This is repeated 5 times to generate stable results.
 
 === x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
 
 ==== Addition
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 55,811
-| 1.062
+| 118,040
+| 1.303
 | `double`
-| 52,531
+| 90,579
 | 1.000
 | `decimal32_t`
-| 2,653,456
-| 50.512
+| 1,712,396
+| 18.905
 | `decimal64_t`
-| 3,254,833
-| 61.960
+| 1,575,893
+| 17.398
 | `decimal128_t`
-| 10,479,050
-| 199.483
+| 3,181,562
+| 35.125
 | `decimal_fast32_t`
-| 1,371,022
-| 26.100
+| 729,257
+| 8.051
 | `decimal_fast64_t`
-| 1,370,192
-| 26.083
+| 1,083,923
+| 11.967
 | `decimal_fast128_t`
-| 7,197,718
-| 137.018
+| 1,367,004
+| 15.092
+| `Intel Decimal32`
+| 1,159,069
+| 12.796
+| `Intel Decimal64`
+| 1,248,111
+| 13.779
+| `Intel Decimal128`
+| 2,099,084
+| 23.174
+|===
+
+And on the same platform with GCC 13.3.0
+
+|===
+| Type | Runtime (us) | Ratio to `double`
+| `float`
+| 79,256
+| 1.085
+| `double`
+| 73,017
+| 1.000
+| `decimal32_t`
+| 1,501,645
+| 20.566
+| `decimal64_t`
+| 1,567,250
+| 21.464
+| `decimal128_t`
+| 4,609,413
+| 63.128
+| `decimal_fast32_t`
+| 735,864
+| 10.078
+| `decimal_fast64_t`
+| 1,002,119
+| 13.724
+| `decimal_fast128_t`
+| 1,329,644
+| 18.210
 | GCC `_Decimal32`
-| 2,997,658
-| 57.065
+| 2,975,146
+| 40.746
 | GCC `_Decimal64`
-| 2,129,898
-| 40.546
+| 2,186,565
+| 29.946
 | GCC `_Decimal128`
-| 3,056,979
-| 58.194
+| 3,368,864
+| 46.138
 |===
 
 ==== Subtraction

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -957,28 +957,34 @@ Run using a Macbook pro with M4 Max chipset running macOS Sequoia 15.5 and homeb
 
 ===== x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and GCC 13.3.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 2,839,146
-| 0.841
+| 2,920,036
+| 0.850
 | `double`
-| 3,374,946
+| 3,436,919
 | 1.000
 | `decimal32_t`
-| 4,253,304
-| 1.260
+| 4,136,631
+| 1.204
 | `decimal64_t`
-| 6,885,679
-| 2.040
+| 4,318,996
+| 1.257
+| `decimal128_t`
+| 14,624,180
+| 4.255
 | `decimal_fast32_t`
-| 4,453,957
-| 1.320
+| 4,752,219
+| 1.383
 | `decimal_fast64_t`
-| 7,827,910
-| 2.319
+| 4,382,014
+| 1.275
+| `decimal_fast128_t`
+| 17,350,588
+| 5.048
 |===
 
 ===== x64 Windows Results
@@ -1048,23 +1054,29 @@ Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 5,226,353
-| 0.957
+| 5,541,073
+| 0.969
 | `double`
-| 5,458,987
+| 5,716,626
 | 1.000
 | `decimal32_t`
-| 3,782,692
-| 0.693
+| 3,527,433
+| 0.617
 | `decimal64_t`
-| 5,368,162
-| 0.983
+| 4,125,772
+| 0.722
+| `decimal128_t`
+| 6,967,211
+| 1.219
 | `decimal_fast32_t`
-| 3,611,498
-| 0.662
+| 3,654,219
+| 0.639
 | `decimal_fast64_t`
-| 6,025,340
-| 1.104
+| 3,386,125
+| 0.592
+| `decimal_fast128_t`
+| 6,018,439
+| 1.053
 |===
 
 ===== x64 Windows Results

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -14,6 +14,9 @@ The values in the ratio column are how many times longer running a specific oper
 
 IMPORTANT: On nearly all platforms there is hardware support for binary floating point math, so we are comparing hardware to software runtimes; *Decimal will be slower*
 
+NOTE: Both the results from Intel and GCC types are from very close, but not identical benchmark routines since they are written in C instead of C\++.
+We assume they are close enough, and the differences between the C and C++ compilers are small enough, for fair comparison
+
 == How to run the Benchmarks
 [#run_benchmarks_]
 

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -28,43 +28,79 @@ This is repeated 5 times to generate stable results.
 
 === x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 34,814
-| 0.604
+| 72,696
+| 0.505
 | `double`
-| 57,644
+| 143,924
 | 1.000
 | `decimal32_t`
-| 2,163,595
-| 37.534
+| 1,485,786
+| 10.323
 | `decimal64_t`
-| 2,633,923
-| 45.693
+| 1,653,991
+| 11.492
 | `decimal128_t`
-| 6,064,630
-| 105.208
+| 4,662,704
+| 32.397
 | `decimal_fast32_t`
-| 613,626
-| 10.645
+| 619,662
+| 4.305
 | `decimal_fast64_t`
-| 693,390
-| 12.029
+| 606,382
+| 4.213
 | `decimal_fast128_t`
-| 628,596
-| 10.905
-| GCC `_decimal32_t`
-| 893,375
-| 15.498
-| GCC `_decimal64_t`
-| 496,127
-| 8.607
-| GCC `_decimal128_t`
-| 1,143,636
-| 19.840
+| 698,945
+| 4.856
+| `Intel Decimal32`
+| 2,023,493
+| 14.059
+| `Intel Decimal64`
+| 2,386,409
+| 16.581
+|===
+
+And on the same platform with GCC 13.3.0
+
+|===
+| Type | Runtime (us) | Ratio to `double`
+| `float`
+| 56,457
+| 0.916
+| `double`
+| 61,615
+| 1.000
+| `decimal32_t`
+| 1,404,638
+| 22.797
+| `decimal64_t`
+| 1,408,074
+| 22.853
+| `decimal128_t`
+| 4,974,170
+| 80.730
+| `decimal_fast32_t`
+| 546,836
+| 8.875
+| `decimal_fast64_t`
+| 472,387
+| 7.667
+| `decimal_fast128_t`
+| 480,853
+| 7.804
+| GCC `_Decimal32`
+| 816,703
+| 13.255
+| GCC `_Decimal64`
+| 501,479
+| 8.139
+| GCC `_Decimal128`
+| 914,600
+| 14.844
 |===
 
 === x64 Windows Results
@@ -173,13 +209,13 @@ Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
 | `decimal_fast128_t`
 | 7,197,718
 | 137.018
-| GCC `_decimal32_t`
+| GCC `_Decimal32`
 | 2,997,658
 | 57.065
-| GCC `_decimal64_t`
+| GCC `_Decimal64`
 | 2,129,898
 | 40.546
-| GCC `_decimal128_t`
+| GCC `_Decimal128`
 | 3,056,979
 | 58.194
 |===
@@ -212,13 +248,13 @@ Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
 | `decimal_fast128_t`
 | 2,073,580
 | 42.110
-| GCC `_decimal32_t`
+| GCC `_Decimal32`
 | 2,006,964
 | 40.757
-| GCC `_decimal64_t`
+| GCC `_Decimal64`
 | 1,324,796
 | 26.904
-| GCC `_decimal128_t`
+| GCC `_Decimal128`
 | 2,783,553
 | 56.528
 |===
@@ -251,13 +287,13 @@ Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
 | `decimal_fast128_t`
 | 8,139,518
 | 166.442
-| GCC `_decimal32_t`
+| GCC `_Decimal32`
 | 2,507,998
 | 51.285
-| GCC `_decimal64_t`
+| GCC `_Decimal64`
 | 2,414,864
 | 49.381
-| GCC `_decimal128_t`
+| GCC `_Decimal128`
 | 6,248,956
 | 127.783
 |===
@@ -290,13 +326,13 @@ Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
 | `decimal_fast128_t`
 | 1,243,024
 | 15.920
-| GCC `_decimal32_t`
+| GCC `_Decimal32`
 | 5,002,197
 | 64.067
-| GCC `_decimal64_t`
+| GCC `_Decimal64`
 | 2,961,731
 | 37.933
-| GCC `_decimal128_t`
+| GCC `_Decimal128`
 | 10,095,995
 | 129.307
 |===

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -424,41 +424,83 @@ And on the same platform with GCC 13.3.0
 
 ==== Division
 
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
+
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 59,003
-| 0.756
+| 100,799
+| 0.971
 | `double`
-| 78,078
+| 103,796
 | 1.000
 | `decimal32_t`
-| 2,250,186
-| 28.820
+| 2,125,437
+| 20.477
 | `decimal64_t`
-| 2,816,014
-| 36.067
+| 5,973,337
+| 57.549
 | `decimal128_t`
-| 18,320,634
-| 234.645
+| 9,482,403
+| 91.356
 | `decimal_fast32_t`
-| 1,123,428
-| 14.389
+| 1,011,695
+| 9.747
 | `decimal_fast64_t`
-| 1,258,004
-| 16.112
+| 2,138,793
+| 20.606
 | `decimal_fast128_t`
-| 1,243,024
-| 15.920
+| 8,277,721
+| 79.750
+// For unknown reasons this function segfaults
+//| `Intel Decimal32`
+//| 931,655
+//| 12.798
+//| `Intel Decimal64`
+//| 963,464
+//| 13.235
+//| `Intel Decimal128`
+//| 2,162,490
+//| 29.545
+|===
+
+And on the same platform with GCC 13.3.0
+
+|===
+| Type | Runtime (us) | Ratio to `double`
+| `float`
+| 60,277
+| 0.747
+| `double`
+| 80,676
+| 1.000
+| `decimal32_t`
+| 2,396,732
+| 29.708
+| `decimal64_t`
+| 4,824,865
+| 59.805
+| `decimal128_t`
+| 10,751,669
+| 133.270
+| `decimal_fast32_t`
+| 1,103,023
+| 13.672
+| `decimal_fast64_t`
+| 2,384,925
+| 29.562
+| `decimal_fast128_t`
+| 8,332,936
+| 103.289
 | GCC `_Decimal32`
-| 5,002,197
-| 64.067
+| 5,082,812
+| 63.002
 | GCC `_Decimal64`
-| 2,961,731
-| 37.933
+| 3,005,153
+| 37.250
 | GCC `_Decimal128`
-| 10,095,995
-| 129.307
+| 10,257,437
+| 130.490
 |===
 
 === x64 Windows Results

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -771,28 +771,34 @@ These benchmarks are automatically disabled if your compiler does not provide fe
 
 ===== x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and GCC 13.3.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 10,308,818
-| 0.551
+| 2,437,788
+| 0.917
 | `double`
-| 18,692,513
+| 2,657,378
 | 1.000
 | `decimal32_t`
-| 3,301,003
-| 0.177
+| 3,131,251
+| 1.178
 | `decimal64_t`
-| 4,580,001
-| 0.245
+| 4,291,891
+| 1.615
+| `decimal128_t`
+| 9,911,474
+| 3.730
 | `decimal_fast32_t`
-| 3,321,788
-| 0.178
+| 4,737,095
+| 1.783
 | `decimal_fast64_t`
-| 4,591,311
-| 0.246
+| 4,404,334
+| 1.657
+| `decimal_fast128_t`
+| 10,414,943
+| 3.919
 |===
 
 ===== x64 Windows Results
@@ -857,28 +863,34 @@ Run using a Macbook pro with M4 Max chipset running macOS Sequoia 15.5 and homeb
 
 ===== x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and GCC 13.3.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 10,363,219
-| 0.554
+| 2,506,008
+| 0.954
 | `double`
-| 18,677,179
+| 2,625,702
 | 1.000
 | `decimal32_t`
-| 3,296,877
-| 0.177
+| 3,008,653
+| 1.146
 | `decimal64_t`
-| 4,500,127
-| 0.241
+| 4,180,192
+| 1.592
+| `decimal128_t`
+| 9,712,229
+| 3.699
 | `decimal_fast32_t`
-| 3,381,651
-| 0.181
+| 4,142,588
+| 1.578
 | `decimal_fast64_t`
-| 4,496,194
-| 0.241
+| 4,118,461
+| 1.569
+| `decimal_fast128_t`
+| 8,772,097
+| 3.341
 |===
 
 ===== x64 Windows Results

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -263,41 +263,84 @@ And on the same platform with GCC 13.3.0
 
 ==== Subtraction
 
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and Intel oneAPI compiler 2025.2.0.
+
+==== Addition
+
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 53,362
-| 1.083
+| 78,250
+| 1.069
 | `double`
-| 49,242
+| 73,193
 | 1.000
 | `decimal32_t`
-| 2,054,535
-| 41.723
+| 1,480,678
+| 20.229
 | `decimal64_t`
-| 2,507,709
-| 50.926
+| 1,371,677
+| 18.741
 | `decimal128_t`
-| 5,554,139
-| 112.793
+| 2,768,955
+| 37.831
 | `decimal_fast32_t`
-| 1,050,225
-| 21.328
+| 1,040,587
+| 14.217
 | `decimal_fast64_t`
-| 1,048,560
-| 21.294
+| 1,055,980
+| 14.427
 | `decimal_fast128_t`
-| 2,073,580
-| 42.110
+| 1,212,405
+| 16.564
+| `Intel Decimal32`
+| 1,275,562
+| 17.427
+| `Intel Decimal64`
+| 1,019,947
+| 13.935
+| `Intel Decimal128`
+| 2,162,490
+| 29.545
+|===
+
+And on the same platform with GCC 13.3.0
+
+|===
+| Type | Runtime (us) | Ratio to `double`
+| `float`
+| 275,230
+| 0.936
+| `double`
+| 293,907
+| 1.000
+| `decimal32_t`
+| 1,451,610
+| 4.939
+| `decimal64_t`
+| 1,456,587
+| 4.956
+| `decimal128_t`
+| 4,332,644
+| 14.742
+| `decimal_fast32_t`
+| 842,910
+| 2.868
+| `decimal_fast64_t`
+| 968,939
+| 3.297
+| `decimal_fast128_t`
+| 1,327,411
+| 4.516
 | GCC `_Decimal32`
-| 2,006,964
-| 40.757
+| 2,045,306
+| 6.959
 | GCC `_Decimal64`
-| 1,324,796
-| 26.904
+| 1,355,777
+| 4.613
 | GCC `_Decimal128`
-| 2,783,553
-| 56.528
+| 3,178,891
+| 10.816
 |===
 
 ==== Multiplication

--- a/doc/modules/ROOT/pages/benchmarks.adoc
+++ b/doc/modules/ROOT/pages/benchmarks.adoc
@@ -1141,28 +1141,34 @@ Run using a Macbook pro with M4 Max chipset running macOS Sequoia 15.5 and homeb
 
 ===== x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and GCC 13.3.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 2,835,528
-| 0.849
+| 2,841,569
+| 0.827
 | `double`
-| 3,338,216
+| 3,437,387
 | 1.000
 | `decimal32_t`
-| 2,887,451
-| 0.865
+| 2,564,053
+| 0.750
 | `decimal64_t`
-| 5,218,195
-| 1.563
+| 2,856,944
+| 0.831
+| `decimal128_t`
+| 12,147,039
+| 3.534
 | `decimal_fast32_t`
-| 3,033,115
-| 0.909
+| 2,878,507
+| 0.837
 | `decimal_fast64_t`
-| 6,103,323
-| 1.828
+| 2,933,273
+| 0.853
+| `decimal_fast128_t`
+| 15,010,374
+| 4.367
 |===
 
 ===== x64 Windows Results
@@ -1227,28 +1233,34 @@ Run using a Macbook pro with M4 Max chipset running macOS Sequoia 15.5 and homeb
 
 ===== x64 Linux Results
 
-Run using an Intel i9-11900k chipset running RHEL 9.4 and GCC 11.4.1-3
+Run using an Intel i9-11900k chipset running Ubuntu 24.04 and GCC 13.3.0.
 
 |===
 | Type | Runtime (us) | Ratio to `double`
 | `float`
-| 4,686,460
-| 0.938
+| 4,896,523
+| 0.958
 | `double`
-| 4,993,886
+| 5,112,924
 | 1.000
 | `decimal32_t`
-| 2,919,727
-| 0.585
+| 2,542,237
+| 0.497
 | `decimal64_t`
-| 4,157,802
-| 0.833
+| 3,119,552
+| 0.610
+| `decimal128_t`
+| 4,811,741
+| 0.941
 | `decimal_fast32_t`
-| 3,052,228
-| 0.611
+| 2,890,023
+| 0.565
 | `decimal_fast64_t`
-| 5,597,538
-| 1.121
+| 2,956,466
+| 0.578
+| `decimal_fast128_t`
+| 5,476,431
+| 1.071
 |===
 
 ===== x64 Windows Results

--- a/test/benchmark_libbid.c
+++ b/test/benchmark_libbid.c
@@ -1,0 +1,359 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#define _POSIX_C_SOURCE 199309L
+#define DECIMAL_GLOBAL_ROUNDING 1
+#define DECIMAL_GLOBAL_EXCEPTION_FLAGS 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
+#include <inttypes.h>
+#include <float.h>
+#include <fenv.h>
+
+typedef uint32_t Decimal32;
+typedef uint64_t Decimal64;
+#include "../LIBRARY/src/bid_conf.h"
+#include "../LIBRARY/src/bid_functions.h"
+typedef BID_UINT128 Decimal128;
+
+#define K 20000000
+#define N 5
+
+uint32_t random_uint32(void) 
+{
+    uint32_t r = 0;
+    for (int i = 0; i < 2; i++) 
+    {
+        r = (r << 16) | (rand() & 0xFFFF);
+    }
+    
+    return r;
+}
+
+uint64_t random_uint64(void) 
+{
+    uint32_t r = 0;
+    for (int i = 0; i < 4; i++) 
+    {
+        r = (r << 16) | (rand() & 0xFFFF);
+    }
+    
+    return r;
+}
+
+__attribute__ ((noinline)) void generate_vector_32(Decimal32* buffer, size_t buffer_len)
+{
+    for (size_t i = 0; i < buffer_len; ++i)
+    {
+        buffer[i] = bid32_from_uint32(random_uint32() % 100);
+    }
+}
+
+__attribute__ ((noinline)) void test_comparisons_32(Decimal32* data, const char* label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal32 val1 = data[k];
+            Decimal32 val2 = data[k + 1];
+
+            s += (size_t)bid32_quiet_less(val1, val2);
+            s += (size_t)bid32_quiet_less_equal(val1, val2);
+            s += (size_t)bid32_quiet_greater(val1, val2);
+            s += (size_t)bid32_quiet_greater_equal(val1, val2);
+            s += (size_t)bid32_quiet_equal(val1, val2);
+            s += (size_t)bid32_quiet_not_equal(val1, val2);
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("Comparisons    <%-10s >: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
+}
+
+__attribute__ ((noinline)) void generate_vector_64(Decimal64* buffer, size_t buffer_len)
+{
+    for (size_t i = 0; i < buffer_len; ++i)
+    {
+        buffer[i] = bid64_from_uint64(random_uint64() % 10000);
+    }
+}
+
+__attribute__ ((noinline)) void test_comparisons_64(Decimal64* data, const char* label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal64 val1 = data[k];
+            Decimal64 val2 = data[k + 1];
+
+            s += (size_t)bid64_quiet_less(val1, val2);
+            s += (size_t)bid64_quiet_less_equal(val1, val2);
+            s += (size_t)bid64_quiet_greater(val1, val2);
+            s += (size_t)bid64_quiet_greater_equal(val1, val2);
+            s += (size_t)bid64_quiet_equal(val1, val2);
+            s += (size_t)bid64_quiet_not_equal(val1, val2);
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("Comparisons    <%-10s >: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
+}
+
+
+__attribute__ ((__noinline__)) void generate_vector_128(Decimal128* buffer, size_t buffer_len)
+{
+    size_t i = 0;
+    while (i < buffer_len)
+    {
+        buffer[i] = bid128_from_uint64(random_uint64() % 100);
+        ++i;
+    }
+}
+
+__attribute__ ((__noinline__)) void test_comparisons_128(Decimal128* data, const char* label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal128 val1 = data[k];
+            Decimal128 val2 = data[k + 1];
+
+            s += (size_t)bid128_quiet_less(val1, val2);
+            s += (size_t)bid128_quiet_less_equal(val1, val2);
+            s += (size_t)bid128_quiet_greater(val1, val2);
+            s += (size_t)bid128_quiet_greater_equal(val1, val2);
+            s += (size_t)bid128_quiet_equal(val1, val2);
+            s += (size_t)bid128_quiet_not_equal(val1, val2);
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("Comparisons    <%-10s >: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
+}
+
+
+typedef Decimal32 (*operation_32)(Decimal32, Decimal32);
+
+__attribute__ ((noinline)) Decimal32 add_32(Decimal32 a, Decimal32 b)
+{
+    return bid32_add(a, b);
+}
+__attribute__ ((noinline)) Decimal32 sub_32(Decimal32 a, Decimal32 b)
+{
+    return bid32_sub(a, b);
+}
+
+__attribute__ ((noinline)) Decimal32 mul_32(Decimal32 a, Decimal32 b)
+{
+    return bid32_mul(a, b);
+}
+
+__attribute__ ((noinline)) Decimal32 div_32(Decimal32 a, Decimal32 b)
+{
+    return bid32_div(a, b);
+}
+
+__attribute__ ((noinline)) void test_two_element_operation_32(Decimal32* data, operation_32 op, const char* label, const char* op_label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal32 val1 = data[k];
+            Decimal32 val2 = data[k + 1];
+
+            s += (size_t)bid32_to_int32_int(op(val1, val2));
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("%-15s<%-10s >: %-10" PRIu64 " us (s=%zu)\n", op_label, label, elapsed_time_us, s);
+}
+
+typedef Decimal64 (*operation_64)(Decimal64, Decimal64);
+
+__attribute__ ((noinline)) Decimal64 add_64(Decimal64 a, Decimal64 b)
+{
+    return bid64_add(a, b);
+}
+
+__attribute__ ((noinline)) Decimal64 sub_64(Decimal64 a, Decimal64 b)
+{
+    return bid64_sub(a, b);
+}
+
+__attribute__ ((noinline)) Decimal64 mul_64(Decimal64 a, Decimal64 b)
+{
+    return bid64_mul(a, b);
+}
+
+__attribute__ ((noinline)) Decimal64 div_64(Decimal64 a, Decimal64 b)
+{
+    return bid64_div(a, b);
+}
+
+__attribute__ ((noinline)) void test_two_element_operation_64(Decimal64* data, operation_64 op, const char* label, const char* op_label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal64 val1 = data[k];
+            Decimal64 val2 = data[k + 1];
+
+            s += (size_t)bid64_to_int64_int(op(val1, val2));
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("%-15s<%-10s >: %-10" PRIu64 " us (s=%zu)\n", op_label, label, elapsed_time_us, s);
+}
+
+
+typedef Decimal128 (*operation_128)(Decimal128, Decimal128);
+
+__attribute__ ((__noinline__)) Decimal128 add_128(Decimal128 a, Decimal128 b)
+{
+    return bid128_add(a, b);
+}
+
+__attribute__ ((__noinline__)) Decimal128 sub_128(Decimal128 a, Decimal128 b)
+{
+    return bid128_sub(a, b);
+}
+
+__attribute__ ((__noinline__)) Decimal128 mul_128(Decimal128 a, Decimal128 b)
+{
+    return bid128_mul(a, b);
+}
+
+__attribute__ ((__noinline__)) Decimal128 div_128(Decimal128 a, Decimal128 b)
+{
+    return bid128_div(a, b);
+}
+
+__attribute__ ((__noinline__)) void test_two_element_operation_128(Decimal128* data, operation_128 op, const char* label, const char* op_label)
+{
+    struct timespec t1, t2;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    
+    size_t s = 0;
+
+    for (size_t n = 0; n < N; ++n)
+    {
+        for (size_t k = 0; k < K - 1; ++k)
+        {
+            Decimal128 val1 = data[k];
+            Decimal128 val2 = data[k + 1];
+
+            s += (size_t)bid128_to_int64_int(op(val1, val2));
+        }
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t2);
+
+    uint64_t elapsed_time_us = (uint64_t)((t2.tv_sec - t1.tv_sec) * 1000000 + (t2.tv_nsec - t1.tv_nsec) / 1000);
+    printf("%-15s<%-10s >: %-10" PRIu64 " us (s=%zu)\n", op_label, label, elapsed_time_us, s);
+}
+
+
+int main()
+{
+    // One time init of random number generator
+    srand(time(NULL));
+
+    fedisableexcept(FE_ALL_EXCEPT);
+    
+    Decimal32* d32_array = malloc(K * sizeof(Decimal32));
+    Decimal64* d64_array = malloc(K * sizeof(Decimal64));
+    Decimal128* d128_array = malloc(K * sizeof(Decimal128));
+    
+    if (d32_array == NULL|| d64_array == NULL  || d128_array == NULL)
+    {
+        return 1;
+    }
+
+    printf("== Generating Arrays ==\n");
+
+    generate_vector_32(d32_array, K);
+    generate_vector_64(d64_array, K);
+    generate_vector_128(d128_array, K);
+
+    printf("===== Comparisons =====\n");
+
+    test_comparisons_32(d32_array, "Decimal32");
+    test_comparisons_64(d64_array, "Decimal64");
+    test_comparisons_128(d128_array, "Decimal128");
+    
+    printf("\n===== Addition =====\n");
+
+    test_two_element_operation_32(d32_array, add_32, "Decimal32", "Addition");
+    test_two_element_operation_64(d64_array, add_64, "Decimal64", "Addition");
+    test_two_element_operation_128(d128_array, add_128, "Decimal128", "Addition");
+
+    printf("\n===== Subtraction =====\n");
+
+    test_two_element_operation_32(d32_array, sub_32, "Decimal32", "Subtraction");
+    test_two_element_operation_64(d64_array, sub_64, "Decimal64", "Subtraction");
+    test_two_element_operation_128(d128_array, sub_128, "Decimal128", "Subtraction");
+
+    printf("\n===== Multiplication =====\n");
+
+    test_two_element_operation_32(d32_array, mul_32, "Decimal32", "Multiplication");
+    test_two_element_operation_64(d64_array, mul_64, "Decimal64", "Multiplication");
+    test_two_element_operation_128(d128_array, mul_128, "Decimal128", "Multiplication");
+
+    printf("\n===== Division =====\n");
+
+    test_two_element_operation_32(d32_array, div_32, "Decimal32", "Division");
+    test_two_element_operation_64(d64_array, div_64, "Decimal64", "Division");
+    test_two_element_operation_128(d128_array, div_128, "Decimal128", "Division");
+
+    free(d32_array);
+    free(d64_array);
+    free(d128_array);
+
+    return 0;
+}

--- a/test/benchmark_libdfp.c
+++ b/test/benchmark_libdfp.c
@@ -17,7 +17,7 @@ double float_rand(double min, double max)
     return min + scale * (max - min);
 }
 
-__attribute__ ((__noinline__)) void generate_vector_32(_decimal32_t* buffer, size_t buffer_len)
+__attribute__ ((__noinline__)) void generate_vector_32(_Decimal32* buffer, size_t buffer_len)
 {
     size_t i = 0;
     while (i < buffer_len)
@@ -27,7 +27,7 @@ __attribute__ ((__noinline__)) void generate_vector_32(_decimal32_t* buffer, siz
     }
 }
 
-__attribute__ ((__noinline__)) void test_comparisons_32(_decimal32_t* data, const char* label)
+__attribute__ ((__noinline__)) void test_comparisons_32(_Decimal32* data, const char* label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -38,8 +38,8 @@ __attribute__ ((__noinline__)) void test_comparisons_32(_decimal32_t* data, cons
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal32_t val1 = data[k];
-            _decimal32_t val2 = data[k + 1];
+            _Decimal32 val1 = data[k];
+            _Decimal32 val2 = data[k + 1];
 
             s += (size_t)(val1 > val2);
             s += (size_t)(val1 >= val2);
@@ -56,7 +56,7 @@ __attribute__ ((__noinline__)) void test_comparisons_32(_decimal32_t* data, cons
     printf("Comparisons    <%-10s >: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
 }
 
-__attribute__ ((__noinline__)) void generate_vector_64(_decimal64_t* buffer, size_t buffer_len)
+__attribute__ ((__noinline__)) void generate_vector_64(_Decimal64* buffer, size_t buffer_len)
 {
     size_t i = 0;
     while (i < buffer_len)
@@ -66,7 +66,7 @@ __attribute__ ((__noinline__)) void generate_vector_64(_decimal64_t* buffer, siz
     }
 }
 
-__attribute__ ((__noinline__)) void test_comparisons_64(_decimal64_t* data, const char* label)
+__attribute__ ((__noinline__)) void test_comparisons_64(_Decimal64* data, const char* label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -77,8 +77,8 @@ __attribute__ ((__noinline__)) void test_comparisons_64(_decimal64_t* data, cons
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal64_t val1 = data[k];
-            _decimal64_t val2 = data[k + 1];
+            _Decimal64 val1 = data[k];
+            _Decimal64 val2 = data[k + 1];
 
             s += (size_t)(val1 > val2);
             s += (size_t)(val1 >= val2);
@@ -95,7 +95,7 @@ __attribute__ ((__noinline__)) void test_comparisons_64(_decimal64_t* data, cons
     printf("Comparisons    <%-10s >: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
 }
 
-__attribute__ ((__noinline__)) void generate_vector_128(_decimal128_t* buffer, size_t buffer_len)
+__attribute__ ((__noinline__)) void generate_vector_128(_Decimal128* buffer, size_t buffer_len)
 {
     size_t i = 0;
     while (i < buffer_len)
@@ -105,7 +105,7 @@ __attribute__ ((__noinline__)) void generate_vector_128(_decimal128_t* buffer, s
     }
 }
 
-__attribute__ ((__noinline__)) void test_comparisons_128(_decimal128_t* data, const char* label)
+__attribute__ ((__noinline__)) void test_comparisons_128(_Decimal128* data, const char* label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -116,8 +116,8 @@ __attribute__ ((__noinline__)) void test_comparisons_128(_decimal128_t* data, co
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal128_t val1 = data[k];
-            _decimal128_t val2 = data[k + 1];
+            _Decimal128 val1 = data[k];
+            _Decimal128 val2 = data[k + 1];
 
             s += (size_t)(val1 > val2);
             s += (size_t)(val1 >= val2);
@@ -134,28 +134,28 @@ __attribute__ ((__noinline__)) void test_comparisons_128(_decimal128_t* data, co
     printf("Comparisons    <%-10s>: %-10" PRIu64 " us (s=%zu)\n", label, elapsed_time_us, s);
 }
 
-typedef _decimal32_t (*operation_32)(_decimal32_t, _decimal32_t);
+typedef _Decimal32 (*operation_32)(_Decimal32, _Decimal32);
 
-__attribute__ ((__noinline__)) _decimal32_t add_32(_decimal32_t a, _decimal32_t b)
+__attribute__ ((__noinline__)) _Decimal32 add_32(_Decimal32 a, _Decimal32 b)
 {
     return a + b;
 }
-__attribute__ ((__noinline__)) _decimal32_t sub_32(_decimal32_t a, _decimal32_t b)
+__attribute__ ((__noinline__)) _Decimal32 sub_32(_Decimal32 a, _Decimal32 b)
 {
     return a - b;
 }
 
-__attribute__ ((__noinline__)) _decimal32_t mul_32(_decimal32_t a, _decimal32_t b)
+__attribute__ ((__noinline__)) _Decimal32 mul_32(_Decimal32 a, _Decimal32 b)
 {
     return a * b;
 }
 
-__attribute__ ((__noinline__)) _decimal32_t div_32(_decimal32_t a, _decimal32_t b)
+__attribute__ ((__noinline__)) _Decimal32 div_32(_Decimal32 a, _Decimal32 b)
 {
     return a / b;
 }
 
-__attribute__ ((__noinline__)) void test_two_element_operation_32(_decimal32_t* data, operation_32 op, const char* label, const char* op_label)
+__attribute__ ((__noinline__)) void test_two_element_operation_32(_Decimal32* data, operation_32 op, const char* label, const char* op_label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -166,8 +166,8 @@ __attribute__ ((__noinline__)) void test_two_element_operation_32(_decimal32_t* 
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal32_t val1 = data[k];
-            _decimal32_t val2 = data[k + 1];
+            _Decimal32 val1 = data[k];
+            _Decimal32 val2 = data[k + 1];
 
             s += (size_t)op(val1, val2);
         }
@@ -179,29 +179,29 @@ __attribute__ ((__noinline__)) void test_two_element_operation_32(_decimal32_t* 
     printf("%-15s<%-10s >: %-10" PRIu64 " us (s=%zu)\n", op_label, label, elapsed_time_us, s);
 }
 
-typedef _decimal64_t (*operation_64)(_decimal64_t, _decimal64_t);
+typedef _Decimal64 (*operation_64)(_Decimal64, _Decimal64);
 
-__attribute__ ((__noinline__)) _decimal64_t add_64(_decimal64_t a, _decimal64_t b)
+__attribute__ ((__noinline__)) _Decimal64 add_64(_Decimal64 a, _Decimal64 b)
 {
     return a + b;
 }
 
-__attribute__ ((__noinline__)) _decimal64_t sub_64(_decimal64_t a, _decimal64_t b)
+__attribute__ ((__noinline__)) _Decimal64 sub_64(_Decimal64 a, _Decimal64 b)
 {
     return a - b;
 }
 
-__attribute__ ((__noinline__)) _decimal64_t mul_64(_decimal64_t a, _decimal64_t b)
+__attribute__ ((__noinline__)) _Decimal64 mul_64(_Decimal64 a, _Decimal64 b)
 {
     return a * b;
 }
 
-__attribute__ ((__noinline__)) _decimal64_t div_64(_decimal64_t a, _decimal64_t b)
+__attribute__ ((__noinline__)) _Decimal64 div_64(_Decimal64 a, _Decimal64 b)
 {
     return a / b;
 }
 
-__attribute__ ((__noinline__)) void test_two_element_operation_64(_decimal64_t* data, operation_64 op, const char* label, const char* op_label)
+__attribute__ ((__noinline__)) void test_two_element_operation_64(_Decimal64* data, operation_64 op, const char* label, const char* op_label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -212,8 +212,8 @@ __attribute__ ((__noinline__)) void test_two_element_operation_64(_decimal64_t* 
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal64_t val1 = data[k];
-            _decimal64_t val2 = data[k + 1];
+            _Decimal64 val1 = data[k];
+            _Decimal64 val2 = data[k + 1];
 
             s += (size_t)op(val1, val2);
         }
@@ -225,29 +225,29 @@ __attribute__ ((__noinline__)) void test_two_element_operation_64(_decimal64_t* 
     printf("%-15s<%-10s >: %-10" PRIu64 " us (s=%zu)\n", op_label, label, elapsed_time_us, s);
 }
 
-typedef _decimal128_t (*operation_128)(_decimal128_t, _decimal128_t);
+typedef _Decimal128 (*operation_128)(_Decimal128, _Decimal128);
 
-__attribute__ ((__noinline__)) _decimal128_t add_128(_decimal128_t a, _decimal128_t b)
+__attribute__ ((__noinline__)) _Decimal128 add_128(_Decimal128 a, _Decimal128 b)
 {
     return a + b;
 }
 
-__attribute__ ((__noinline__)) _decimal128_t sub_128(_decimal128_t a, _decimal128_t b)
+__attribute__ ((__noinline__)) _Decimal128 sub_128(_Decimal128 a, _Decimal128 b)
 {
     return a - b;
 }
 
-__attribute__ ((__noinline__)) _decimal128_t mul_128(_decimal128_t a, _decimal128_t b)
+__attribute__ ((__noinline__)) _Decimal128 mul_128(_Decimal128 a, _Decimal128 b)
 {
     return a * b;
 }
 
-__attribute__ ((__noinline__)) _decimal128_t div_128(_decimal128_t a, _decimal128_t b)
+__attribute__ ((__noinline__)) _Decimal128 div_128(_Decimal128 a, _Decimal128 b)
 {
     return a / b;
 }
 
-__attribute__ ((__noinline__)) void test_two_element_operation_128(_decimal128_t* data, operation_128 op, const char* label, const char* op_label)
+__attribute__ ((__noinline__)) void test_two_element_operation_128(_Decimal128* data, operation_128 op, const char* label, const char* op_label)
 {
     struct timespec t1, t2;
     clock_gettime(CLOCK_MONOTONIC, &t1);
@@ -258,8 +258,8 @@ __attribute__ ((__noinline__)) void test_two_element_operation_128(_decimal128_t
     {
         for (size_t k = 0; k < K - 1; ++k)
         {
-            _decimal128_t val1 = data[k];
-            _decimal128_t val2 = data[k + 1];
+            _Decimal128 val1 = data[k];
+            _Decimal128 val2 = data[k + 1];
 
             s += (size_t)op(val1, val2);
         }
@@ -276,9 +276,9 @@ int main()
     // One time init of random number generator
     srand(time(NULL));
     
-    _decimal32_t* d32_array = malloc(K * sizeof(_decimal32_t));
-    _decimal64_t* d64_array = malloc(K * sizeof(_decimal64_t));
-    _decimal128_t* d128_array = malloc(K * sizeof(_decimal128_t));
+    _Decimal32* d32_array = malloc(K * sizeof(_Decimal32));
+    _Decimal64* d64_array = malloc(K * sizeof(_Decimal64));
+    _Decimal128* d128_array = malloc(K * sizeof(_Decimal128));
     
     if (d32_array == NULL || d64_array == NULL || d128_array == NULL)
     {
@@ -288,37 +288,37 @@ int main()
     printf("===== Comparisons =====\n");
 
     generate_vector_32(d32_array, K);
-    test_comparisons_32(d32_array, "_decimal32_t");
+    test_comparisons_32(d32_array, "_Decimal32");
 
     generate_vector_64(d64_array, K);
-    test_comparisons_64(d64_array, "_decimal64_t");
+    test_comparisons_64(d64_array, "_Decimal64");
 
     generate_vector_128(d128_array, K);
-    test_comparisons_128(d128_array, "_decimal128_t");
+    test_comparisons_128(d128_array, "_Decimal128");
     
     printf("\n===== Addition =====\n");
 
-    test_two_element_operation_32(d32_array, add_32, "_decimal32_t", "Addition");
-    test_two_element_operation_64(d64_array, add_64, "_decimal64_t", "Addition");
-    test_two_element_operation_128(d128_array, add_128, "_decimal128_t", "Addition");
+    test_two_element_operation_32(d32_array, add_32, "_Decimal32", "Addition");
+    test_two_element_operation_64(d64_array, add_64, "_Decimal64", "Addition");
+    test_two_element_operation_128(d128_array, add_128, "_Decimal128", "Addition");
 
     printf("\n===== Subtraction =====\n");
 
-    test_two_element_operation_32(d32_array, sub_32, "_decimal32_t", "Subtraction");
-    test_two_element_operation_64(d64_array, sub_64, "_decimal64_t", "Subtraction");
-    test_two_element_operation_128(d128_array, sub_128, "_decimal128_t", "Subtraction");
+    test_two_element_operation_32(d32_array, sub_32, "_Decimal32", "Subtraction");
+    test_two_element_operation_64(d64_array, sub_64, "_Decimal64", "Subtraction");
+    test_two_element_operation_128(d128_array, sub_128, "_Decimal128", "Subtraction");
 
     printf("\n===== Multiplication =====\n");
 
-    test_two_element_operation_32(d32_array, mul_32, "_decimal32_t", "Multiplication");
-    test_two_element_operation_64(d64_array, mul_64, "_decimal64_t", "Multiplication");
-    test_two_element_operation_128(d128_array, mul_128, "_decimal128_t", "Multiplication");
+    test_two_element_operation_32(d32_array, mul_32, "_Decimal32", "Multiplication");
+    test_two_element_operation_64(d64_array, mul_64, "_Decimal64", "Multiplication");
+    test_two_element_operation_128(d128_array, mul_128, "_Decimal128", "Multiplication");
 
     printf("\n===== Division =====\n");
 
-    test_two_element_operation_32(d32_array, div_32, "_decimal32_t", "Division");
-    test_two_element_operation_64(d64_array, div_64, "_decimal64_t", "Division");
-    test_two_element_operation_128(d128_array, div_128, "_decimal128_t", "Division");
+    test_two_element_operation_32(d32_array, div_32, "_Decimal32", "Division");
+    test_two_element_operation_64(d64_array, div_64, "_Decimal64", "Division");
+    test_two_element_operation_128(d128_array, div_128, "_Decimal128", "Division");
 
     free(d32_array);
     free(d64_array);


### PR DESCRIPTION
Gets most of the intel benchmarks. The mul for dec128 and all div are segfaulting for some inexplicable reason. Maybe the global error flag?

Closes: #933 
Closes: #807 
