### PR TITLE
Add and document user facing normalization function

### DIFF
--- a/doc/modules/ROOT/pages/cmath.adoc
+++ b/doc/modules/ROOT/pages/cmath.adoc
@@ -580,10 +580,6 @@ The quantize functions do not signal underflow.
 ----
 template <typename Decimal>
 constexpr auto frexp10(Decimal num, int* expptr) noexcept;
-
-constexpr std::uint32_t frexpd32(decimal32_t num, int* expptr) noexcept;
-constexpr std::uint64_t frexpd64(decimal64_t num, int* expptr) noexcept;
-constexpr boost::decimal::detail::uint128 frexpd128(decimal128_t num, int* expptr) noexcept;
 ----
 
 This function is very similar to https://en.cppreference.com/w/cpp/numeric/math/frexp[frexp], but returns the significand and an integral power of 10 since the `FLT_RADIX` of this type is 10.

--- a/doc/modules/ROOT/pages/cmath.adoc
+++ b/doc/modules/ROOT/pages/cmath.adoc
@@ -513,6 +513,8 @@ Effects: If x is an sNaN returns true, otherwise returns false.
 
 [source, c++]
 ----
+namespace boost {
+namespace decimal {
 
 template <typename Decimal>
 constexpr bool samequantum(Decimal x, Decimal y) noexcept;
@@ -520,6 +522,9 @@ constexpr bool samequantum(Decimal x, Decimal y) noexcept;
 constexpr bool samequantumd32(decimal32_t x, decimal32_t y) noexcept;
 constexpr bool samequantumd64(decimal64_t x, decimal64_t y) noexcept;
 constexpr bool samequantumd128(decimal128_t x, decimal128_t y) noexcept;
+
+} // namespace decimal
+} // namepsace boost
 ----
 
 Effects: Determines if the quantum (unbiased) exponents of x and y are the same.
@@ -532,6 +537,8 @@ If exactly one operand is infinity or exactly one operand is NaN, they do not ha
 
 [source, c++]
 ----
+namespace boost {
+namespace decimal {
 
 template <typename Decimal>
 constexpr int quantexp(Decimal x) noexcept;
@@ -539,6 +546,9 @@ constexpr int quantexp(Decimal x) noexcept;
 constexpr int quantexp32(decimal32_t x) noexcept;
 constexpr int quantexp64(decimal64_t x) noexcept;
 constexpr int quantexp128(decimal128_t x) noexcept;
+
+} // namespace decimal
+} // namepsace boost
 ----
 
 Effects: if x is finite, returns its quantum exponent.
@@ -549,6 +559,8 @@ Otherwise, `INT_MIN` is returned.
 
 [source, c++]
 ----
+namespace boost {
+namespace decimal {
 
 template <typename Decimal>
 constexpr Decimal quantized(Decimal x, Decimal y) noexcept;
@@ -556,6 +568,9 @@ constexpr Decimal quantized(Decimal x, Decimal y) noexcept;
 constexpr decimal32_t quantized32(decimal32_t x, decimal32_t y) noexcept;
 constexpr decimal64_t quantized64(decimal64_t x, decimal64_t y) noexcept;
 constexpr decimal128_t quantized128(decimal128_t x, decimal128_t y) noexcept;
+
+} // namespace decimal
+} // namepsace boost
 ----
 
 Returns: a number that is equal in value (except for any rounding) and sign to x, and which has an exponent set to be equal to the exponent of y.
@@ -578,8 +593,14 @@ The quantize functions do not signal underflow.
 
 [source, c++]
 ----
+namespace boost {
+namespace decimal {
+
 template <typename Decimal>
 constexpr auto frexp10(Decimal num, int* expptr) noexcept;
+
+} // namespace decimal
+} // namepsace boost
 ----
 
 This function is very similar to https://en.cppreference.com/w/cpp/numeric/math/frexp[frexp], but returns the significand and an integral power of 10 since the `FLT_RADIX` of this type is 10.
@@ -607,8 +628,14 @@ This function has *NO* effect on fast types since they are always normalized int
 
 [source, c++]
 ----
+namespace boost {
+namespace decimal {
+
 template <typename Decimal>
 constexpr Decimal rescale(Decimal val, int precision = 0);
+
+} // namespace decimal
+} // namespace boost
 ----
 
 The function returns the decimal type with number of fractional digits equal to the value of precision.

--- a/doc/modules/ROOT/pages/cmath.adoc
+++ b/doc/modules/ROOT/pages/cmath.adoc
@@ -585,7 +585,25 @@ constexpr auto frexp10(Decimal num, int* expptr) noexcept;
 This function is very similar to https://en.cppreference.com/w/cpp/numeric/math/frexp[frexp], but returns the significand and an integral power of 10 since the `FLT_RADIX` of this type is 10.
 The significand is normalized to the number of digits of precision the type has (e.g. for decimal32_t it is [1'000'000, 9'999'999]).
 
-=== rescale
+=== `normalize`
+
+[source, c++]
+----
+namespace boost {
+namespace decimal {
+
+template <typename Decimal>
+constexpr Decimal normalize(Decimal val) noexcept;
+
+} // namespace decimal
+} // namepsace boost
+----
+
+Similar to the `frexp10` function above, but rather than returning the normalized significand, and exponent of the Decimal number, it returns a normalized number.
+This removes the effects of xref:basics.adoc[cohorts] on the IEEE 754 compliant types.
+This function has *NO* effect on fast types since they are always normalized internally.
+
+=== `rescale`
 
 [source, c++]
 ----

--- a/include/boost/decimal/cmath.hpp
+++ b/include/boost/decimal/cmath.hpp
@@ -73,6 +73,7 @@
 #include <boost/decimal/detail/cmath/assoc_legendre.hpp>
 #include <boost/decimal/detail/cmath/rescale.hpp>
 #include <boost/decimal/detail/cmath/beta.hpp>
+#include <boost/decimal/detail/cmath/normalize.hpp>
 #include <boost/decimal/numbers.hpp>
 
 // Macros from 3.6.2

--- a/include/boost/decimal/detail/cmath/normalize.hpp
+++ b/include/boost/decimal/detail/cmath/normalize.hpp
@@ -1,0 +1,32 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_DETAIL_CMATH_NORMALIZE_HPP
+#define BOOST_DECIMAL_DETAIL_CMATH_NORMALIZE_HPP
+
+#include <boost/decimal/detail/cmath/frexp10.hpp>
+#include <boost/decimal/detail/attributes.hpp>
+#include <boost/decimal/detail/concepts.hpp>
+
+namespace boost {
+namespace decimal {
+
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType, std::enable_if_t<detail::is_fast_type_v<DecimalType>, bool> = true>
+constexpr DecimalType normalize(const DecimalType& value) noexcept
+{
+    return value;
+}
+
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType, std::enable_if_t<!detail::is_fast_type_v<DecimalType>, bool> = true>
+constexpr DecimalType normalize(const DecimalType value) noexcept
+{
+    int exp {};
+    const auto significand {frexp10(value, &exp)};
+    return DecimalType{significand, exp, signbit(value)};
+}
+
+} // namespace decimal
+} // namespace boost
+
+#endif //BOOST_DECIMAL_DETAIL_CMATH_NORMALIZE_HPP

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -147,6 +147,7 @@ run test_lgamma.cpp ;
 run test_log.cpp ;
 run test_log1p.cpp ;
 run test_log10.cpp ;
+run test_normalize.cpp ;
 run test_parser.cpp ;
 run test_pow.cpp ;
 run test_promotion.cpp ;

--- a/test/test_normalize.cpp
+++ b/test/test_normalize.cpp
@@ -23,6 +23,11 @@ void fast_test()
     }
 }
 
+#if defined(__GNUC__) && __GNUC__ >= 8
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 template <typename DecimalType>
 void ieee_test()
 {
@@ -79,6 +84,10 @@ void ieee_test()
         BOOST_TEST_EQ(val, normalized_val);
     }
 }
+
+#if defined(__GNUC__) && __GNUC__ >= 8
+#  pragma GCC diagnostic pop
+#endif
 
 int main()
 {

--- a/test/test_normalize.cpp
+++ b/test/test_normalize.cpp
@@ -59,12 +59,14 @@ void ieee_test()
     std::memcpy(&int6, &val6, sizeof(integer_type));
     std::memcpy(&int7, &val7, sizeof(integer_type));
     const std::array<integer_type, 7> vals {int1, int2, int3, int4, int5, int6, int7};
+    const std::array<DecimalType, 7> dec_vals {val1, val2, val3, val4, val5, val6, val7};
 
     for (std::size_t i {}; i < vals.size() - 1; ++i)
     {
         for (std::size_t j {i}; j < vals.size(); ++j)
         {
             BOOST_TEST_EQ(vals[i], vals[j]);
+            BOOST_TEST(std::memcmp(&dec_vals[i], &dec_vals[j], sizeof(DecimalType)) == 0);
         }
     }
 

--- a/test/test_normalize.cpp
+++ b/test/test_normalize.cpp
@@ -1,0 +1,92 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <cstring>
+#include <random>
+
+static constexpr std::size_t N = 1024;
+static std::mt19937_64 rng {42};
+
+template <typename DecimalType>
+void fast_test()
+{
+    std::uniform_int_distribution<std::int64_t> dist {INT64_MIN, INT64_MAX};
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const DecimalType val {dist(rng)};
+        const DecimalType normalized_val {boost::decimal::normalize(val)};
+        BOOST_TEST_EQ(val, normalized_val);
+    }
+}
+
+template <typename DecimalType>
+void ieee_test()
+{
+    using integer_type = std::conditional_t<std::is_same<DecimalType, boost::decimal::decimal32_t>::value, std::uint32_t,
+                         std::conditional_t<std::is_same<DecimalType, boost::decimal::decimal64_t>::value, std::uint64_t, boost::int128::uint128_t>>;
+
+    DecimalType val1 {1, 0};
+    val1 = boost::decimal::normalize(val1);
+
+    DecimalType val2 {10, -1};
+    val2 = boost::decimal::normalize(val2);
+
+    DecimalType val3 {100, -2};
+    val3 = boost::decimal::normalize(val3);
+
+    DecimalType val4 {1000, -3};
+    val4 = boost::decimal::normalize(val4);
+
+    DecimalType val5 {10000, -4};
+    val5 = boost::decimal::normalize(val5);
+
+    DecimalType val6 {100000, -5};
+    val6 = boost::decimal::normalize(val6);
+
+    DecimalType val7 {1000000, -6};
+    val7 = boost::decimal::normalize(val7);
+
+    integer_type int1, int2, int3, int4, int5, int6, int7;
+    std::memcpy(&int1, &val1, sizeof(integer_type));
+    std::memcpy(&int2, &val2, sizeof(integer_type));
+    std::memcpy(&int3, &val3, sizeof(integer_type));
+    std::memcpy(&int4, &val4, sizeof(integer_type));
+    std::memcpy(&int5, &val5, sizeof(integer_type));
+    std::memcpy(&int6, &val6, sizeof(integer_type));
+    std::memcpy(&int7, &val7, sizeof(integer_type));
+    const std::array<integer_type, 7> vals {int1, int2, int3, int4, int5, int6, int7};
+
+    for (std::size_t i {}; i < vals.size() - 1; ++i)
+    {
+        for (std::size_t j {i}; j < vals.size(); ++j)
+        {
+            BOOST_TEST_EQ(vals[i], vals[j]);
+        }
+    }
+
+    std::uniform_int_distribution<std::int64_t> dist {INT64_MIN, INT64_MAX};
+
+    for (std::size_t i {}; i < N; ++i)
+    {
+        const DecimalType val {dist(rng)};
+        const DecimalType normalized_val {boost::decimal::normalize(val)};
+        BOOST_TEST_EQ(val, normalized_val);
+    }
+}
+
+int main()
+{
+    fast_test<boost::decimal::decimal_fast32_t>();
+    fast_test<boost::decimal::decimal_fast64_t>();
+    fast_test<boost::decimal::decimal_fast128_t>();
+
+    ieee_test<boost::decimal::decimal32_t>();
+    ieee_test<boost::decimal::decimal64_t>();
+    ieee_test<boost::decimal::decimal128_t>();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Right now the user has `frexp10` to get the components of a normalized number, but no way to internally normalize that value. This gives that functionality to them.

Closes: #954 