### PR TITLE
Fix `<format>` support for clang

### DIFF
--- a/include/boost/decimal/fmt_format.hpp
+++ b/include/boost/decimal/fmt_format.hpp
@@ -99,9 +99,14 @@ constexpr auto parse_impl(ParseContext &ctx)
                 BOOST_DECIMAL_THROW_EXCEPTION(std::logic_error("Invalid format specifier"));
             // LCOV_EXCL_STOP
         }
+        ++it;
     }
 
-    ++it;
+    // Verify we're at the closing brace
+    if (it != ctx.end() && *it != '}')
+    {
+        BOOST_DECIMAL_THROW_EXCEPTION(std::logic_error("Expected '}' in format string")); // LCOV_EXCL_LINE
+    }
 
     return std::make_tuple(ctx_precision, fmt, is_upper, padding_digits, it);
 }

--- a/include/boost/decimal/format.hpp
+++ b/include/boost/decimal/format.hpp
@@ -95,9 +95,14 @@ constexpr auto parse_impl(ParseContext &ctx)
                 BOOST_DECIMAL_THROW_EXCEPTION(std::format_error("Invalid format specifier"));
             // LCOV_EXCL_STOP
         }
+        ++it;
     }
 
-    ++it;
+    // Verify we're at the closing brace
+    if (it != ctx.end() && *it != '}')
+    {
+        BOOST_DECIMAL_THROW_EXCEPTION(std::format_error("Expected '}' in format string")); // LCOV_EXCL_LINE
+    }
 
     return std::make_tuple(ctx_precision, fmt, is_upper, padding_digits, it);
 }

--- a/test/test_format.cpp
+++ b/test/test_format.cpp
@@ -13,9 +13,6 @@ using namespace boost::decimal;
 template <typename T>
 void test_general()
 {
-    // For unknown reasons Clang does not like this empty bracket and throws compiler errors
-    #ifndef __clang__
-
     BOOST_TEST_EQ(std::format("{}", T{1}), "1");
     BOOST_TEST_EQ(std::format("{}", T{10}), "10");
     BOOST_TEST_EQ(std::format("{}", T{100}), "100");
@@ -43,8 +40,6 @@ void test_general()
     BOOST_TEST_EQ(std::format("{}", -std::numeric_limits<T>::quiet_NaN()), "-nan(ind)");
     BOOST_TEST_EQ(std::format("{}", std::numeric_limits<T>::signaling_NaN()), "nan(snan)");
     BOOST_TEST_EQ(std::format("{}", -std::numeric_limits<T>::signaling_NaN()), "-nan(snan)");
-
-    #endif // defined(__clang__)
 
     BOOST_TEST_EQ(std::format("{:g}", T{1}), "1");
     BOOST_TEST_EQ(std::format("{:g}", T{10}), "10");

--- a/test/test_format_fmtlib.cpp
+++ b/test/test_format_fmtlib.cpp
@@ -31,15 +31,15 @@ void test_general()
 
     BOOST_DECIMAL_IF_CONSTEXPR (std::numeric_limits<T>::digits10 <= 7)
     {
-        BOOST_TEST_EQ(fmt::format("{}", T {21, 6}), "2.1e+07");
-        BOOST_TEST_EQ(fmt::format("{}", T {211, 6}), "2.11e+08");
-        BOOST_TEST_EQ(fmt::format("{}", T {2111, 6}), "2.111e+09");
+        BOOST_TEST_EQ(fmt::format("{}", T {21u, 6}), "2.1e+07");
+        BOOST_TEST_EQ(fmt::format("{}", T {211u, 6}), "2.11e+08");
+        BOOST_TEST_EQ(fmt::format("{}", T {2111u, 6}), "2.111e+09");
     }
     else
     {
-        BOOST_TEST_EQ(fmt::format("{}", T {21, 6}), "21000000");
-        BOOST_TEST_EQ(fmt::format("{}", T {211, 6}), "211000000");
-        BOOST_TEST_EQ(fmt::format("{}", T {2111, 6}), "2111000000");
+        BOOST_TEST_EQ(fmt::format("{}", T {21u, 6}), "21000000");
+        BOOST_TEST_EQ(fmt::format("{}", T {211u, 6}), "211000000");
+        BOOST_TEST_EQ(fmt::format("{}", T {2111u, 6}), "2111000000");
     }
 
     BOOST_TEST_EQ(fmt::format("{}", std::numeric_limits<T>::infinity()), "inf");
@@ -59,18 +59,18 @@ void test_general()
 
     BOOST_DECIMAL_IF_CONSTEXPR (std::numeric_limits<T>::digits10 <= 7)
     {
-        BOOST_TEST_EQ(fmt::format("{:g}", T {21, 6, true}), "-2.1e+07");
-        BOOST_TEST_EQ(fmt::format("{:g}", T {211, 6, true}), "-2.11e+08");
-        BOOST_TEST_EQ(fmt::format("{:g}", T {2111, 6, true}), "-2.111e+09");
-        BOOST_TEST_EQ(fmt::format("{:G}", T {21, 6, true}), "-2.1E+07");
-        BOOST_TEST_EQ(fmt::format("{:G}", T {211, 6, true}), "-2.11E+08");
-        BOOST_TEST_EQ(fmt::format("{:G}", T {2111, 6, true}), "-2.111E+09");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {21u, 6, true}), "-2.1e+07");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {211u, 6, true}), "-2.11e+08");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {2111u, 6, true}), "-2.111e+09");
+        BOOST_TEST_EQ(fmt::format("{:G}", T {21u, 6, true}), "-2.1E+07");
+        BOOST_TEST_EQ(fmt::format("{:G}", T {211u, 6, true}), "-2.11E+08");
+        BOOST_TEST_EQ(fmt::format("{:G}", T {2111u, 6, true}), "-2.111E+09");
     }
     else
     {
-        BOOST_TEST_EQ(fmt::format("{:g}", T {21, 6, true}), "-21000000");
-        BOOST_TEST_EQ(fmt::format("{:g}", T {211, 6, true}), "-211000000");
-        BOOST_TEST_EQ(fmt::format("{:g}", T {2111, 6, true}), "-2111000000");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {21u, 6, true}), "-21000000");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {211u, 6, true}), "-211000000");
+        BOOST_TEST_EQ(fmt::format("{:g}", T {2111u, 6, true}), "-2111000000");
     }
 
     BOOST_TEST_EQ(fmt::format("{:g}", std::numeric_limits<T>::infinity()), "inf");
@@ -91,17 +91,17 @@ void test_general()
 template <typename T>
 void test_fixed()
 {
-    BOOST_TEST_EQ(fmt::format("{:f}", T {21, 6, true}), "-21000000.000000");
-    BOOST_TEST_EQ(fmt::format("{:f}", T {211, 6, true}), "-211000000.000000");
-    BOOST_TEST_EQ(fmt::format("{:f}", T {2111, 6, true}), "-2111000000.000000");
+    BOOST_TEST_EQ(fmt::format("{:f}", T {21u, 6, true}), "-21000000.000000");
+    BOOST_TEST_EQ(fmt::format("{:f}", T {211u, 6, true}), "-211000000.000000");
+    BOOST_TEST_EQ(fmt::format("{:f}", T {2111u, 6, true}), "-2111000000.000000");
 
-    BOOST_TEST_EQ(fmt::format("{:.0f}", T {21, 6, true}), std::string{"-21000000"});
-    BOOST_TEST_EQ(fmt::format("{:.0f}", T {211, 6, true}), std::string{"-211000000"});
-    BOOST_TEST_EQ(fmt::format("{:.0f}", T {2111, 6, true}), std::string{"-2111000000"});
+    BOOST_TEST_EQ(fmt::format("{:.0f}", T {21u, 6, true}), std::string{"-21000000"});
+    BOOST_TEST_EQ(fmt::format("{:.0f}", T {211u, 6, true}), std::string{"-211000000"});
+    BOOST_TEST_EQ(fmt::format("{:.0f}", T {2111u, 6, true}), std::string{"-2111000000"});
 
-    BOOST_TEST_EQ(fmt::format("{:.1f}", T {21, 6, true}), std::string{"-21000000.0"});
-    BOOST_TEST_EQ(fmt::format("{:.1f}", T {211, 6, true}), std::string{"-211000000.0"});
-    BOOST_TEST_EQ(fmt::format("{:.1f}", T {2111, 6, true}), std::string{"-2111000000.0"});
+    BOOST_TEST_EQ(fmt::format("{:.1f}", T {21u, 6, true}), std::string{"-21000000.0"});
+    BOOST_TEST_EQ(fmt::format("{:.1f}", T {211u, 6, true}), std::string{"-211000000.0"});
+    BOOST_TEST_EQ(fmt::format("{:.1f}", T {2111u, 6, true}), std::string{"-2111000000.0"});
 
     BOOST_TEST_EQ(fmt::format("{:.0f}", T {0}), "0");
     BOOST_TEST_EQ(fmt::format("{:f}", std::numeric_limits<T>::infinity()), "inf");
@@ -122,13 +122,13 @@ void test_fixed()
 template <typename T>
 void test_scientific()
 {
-    BOOST_TEST_EQ(fmt::format("{:e}", T {21, 6, true}), "-2.100000e+07");
-    BOOST_TEST_EQ(fmt::format("{:e}", T {211, 6, true}), "-2.110000e+08");
-    BOOST_TEST_EQ(fmt::format("{:e}", T {2111, 6, true}), "-2.111000e+09");
+    BOOST_TEST_EQ(fmt::format("{:e}", T {21u, 6, true}), "-2.100000e+07");
+    BOOST_TEST_EQ(fmt::format("{:e}", T {211u, 6, true}), "-2.110000e+08");
+    BOOST_TEST_EQ(fmt::format("{:e}", T {2111u, 6, true}), "-2.111000e+09");
 
-    BOOST_TEST_EQ(fmt::format("{:E}", T {21, 6, true}), "-2.100000E+07");
-    BOOST_TEST_EQ(fmt::format("{:E}", T {211, 6, true}), "-2.110000E+08");
-    BOOST_TEST_EQ(fmt::format("{:E}", T {2111, 6, true}), "-2.111000E+09");
+    BOOST_TEST_EQ(fmt::format("{:E}", T {21u, 6, true}), "-2.100000E+07");
+    BOOST_TEST_EQ(fmt::format("{:E}", T {211u, 6, true}), "-2.110000E+08");
+    BOOST_TEST_EQ(fmt::format("{:E}", T {2111u, 6, true}), "-2.111000E+09");
 
     BOOST_TEST_EQ(fmt::format("{:.0E}", T {0}), "0E+00");
     BOOST_TEST_EQ(fmt::format("{:e}", std::numeric_limits<T>::infinity()), "inf");


### PR DESCRIPTION
Closes: #981 