### PR TITLE
Implement fast path of no precision scientific formatting

### DIFF
--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -270,7 +270,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_nonfinite(char* first, char* last, const T
 }
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
-BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, const chars_format fmt) noexcept -> to_chars_result
+constexpr auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, const chars_format fmt) noexcept -> to_chars_result
 {
     if (signbit(value))
     {
@@ -300,7 +300,8 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
     // since we are always in the print shortest representation realm
     int exp {};
     auto significand {static_cast<uint_type>(frexp10(value, &exp))};
-    exp += static_cast<int>(std::numeric_limits<TargetDecimalType>::digits10 - 1);
+    constexpr int exp_offset {std::numeric_limits<TargetDecimalType>::digits10 - 1};
+    exp += exp_offset;
 
     auto r = to_chars_integer_impl<uint_type>(first + 1, last, significand);
 

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -298,7 +298,7 @@ constexpr auto to_chars_scientific_impl(char* first, char* last, const TargetDec
 
     // Need to offset the exp for the fact that it's not 123e+2, it's 1.23e+4
     const auto components {value.to_components()};
-    auto r = to_chars_integer_impl<uint_type>(first + 1, last, components.sig);
+    auto r = to_chars_integer_impl(first + 1, last, static_cast<uint_type>(components.sig));
 
     // Only real reason we will hit this is a buffer overflow,
     // which we have already checked for

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -307,12 +307,13 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
     auto significand {static_cast<uint_type>(frexp10(value, &exp))};
     const auto trailing_zeros {detail::remove_trailing_zeros(significand)};
     significand = trailing_zeros.trimmed_number;
-    exp += trailing_zeros.number_of_removed_zeros;
+    exp += static_cast<int>(trailing_zeros.number_of_removed_zeros);
 
     // Use an offset of one since we need to insert the decimal point
     const auto significant_digits {std::numeric_limits<TargetDecimalType>::digits10 - trailing_zeros.number_of_removed_zeros};
-    exp += significant_digits - 1;
     BOOST_DECIMAL_ASSERT(significant_digits != 0); // Should have been filtered out
+
+    exp += static_cast<int>(significant_digits - 1);
 
     // If there is only one digit, and we don't need any fractional part
     if (significant_digits == 1)

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -270,7 +270,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_nonfinite(char* first, char* last, const T
 }
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
-BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value) noexcept -> to_chars_result
+BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, const chars_format fmt) noexcept -> to_chars_result
 {
     if (first >= last)
     {
@@ -294,7 +294,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
     const auto fp = fpclassify(value);
     if (!(fp == FP_NORMAL || fp == FP_SUBNORMAL))
     {
-        return to_chars_nonfinite(first, last, value, fp, chars_format::scientific, -1);
+        return to_chars_nonfinite(first, last, value, fp, fmt, -1);
     }
 
     using uint_type = std::conditional_t<(std::numeric_limits<typename TargetDecimalType::significand_type>::digits >
@@ -980,12 +980,12 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_impl(char* first, char* last, const Target
                 }
                 else
                 {
-                    return to_chars_scientific_impl(first, last, value);
+                    return to_chars_scientific_impl(first, last, value, fmt);
                 }
             case chars_format::fixed:
                 return to_chars_fixed_impl(first, last, value, fmt, local_precision);
             case chars_format::scientific:
-                return to_chars_scientific_impl(first, last, value);
+                return to_chars_scientific_impl(first, last, value, fmt);
             case chars_format::hex:
                 return to_chars_hex_impl(first, last, value, local_precision); // LCOV_EXCL_LINE unreachable
         }

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -319,47 +319,23 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
     if (significant_digits == 1)
     {
         *first++ = static_cast<char>(significand);
-        *first++ = 'e';
-
-        // Ensure we have a sign and at least 2 digits e.g. e+00
-        if (exp >= 0)
-        {
-            *first++ = '+';
-        }
-        else
-        {
-            *first++ = '-';
-            exp = -exp;
-        }
-
-        if (exp < 10)
-        {
-            *first++ = '0';
-        }
-
-        const auto exp_r {to_chars_integer_impl(first, last, exp)};
-
-        if (BOOST_DECIMAL_UNLIKELY(!exp_r))
-        {
-            return exp_r; // LCOV_EXCL_LINE
-        }
-
-        return {exp_r.ptr, std::errc{}};
     }
-
-    const auto r = to_chars_integer_impl<uint_type>(first + 1, last, significand);
-
-    // Only real reason we will hit this is a buffer overflow,
-    // which we have already checked for
-    if (BOOST_DECIMAL_UNLIKELY(!r))
+    else
     {
-        return r; // LCOV_EXCL_LINE
-    }
+        const auto r = to_chars_integer_impl<uint_type>(first + 1, last, significand);
 
-    // Insert our decimal point
-    *first = *(first + 1);
-    *(first + 1) = '.';
-    first = r.ptr;
+        // Only real reason we will hit this is a buffer overflow,
+        // which we have already checked for
+        if (BOOST_DECIMAL_UNLIKELY(!r))
+        {
+            return r; // LCOV_EXCL_LINE
+        }
+
+        // Insert our decimal point
+        *first = *(first + 1);
+        *(first + 1) = '.';
+        first = r.ptr;
+    }
 
     *first++ = 'e';
     if (exp >= 0)

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -980,12 +980,12 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_impl(char* first, char* last, const Target
                 }
                 else
                 {
-                    return to_chars_scientific_impl(first, last, value, fmt, local_precision);
+                    return to_chars_scientific_impl(first, last, value);
                 }
             case chars_format::fixed:
                 return to_chars_fixed_impl(first, last, value, fmt, local_precision);
             case chars_format::scientific:
-                return to_chars_scientific_impl(first, last, value, fmt, local_precision);
+                return to_chars_scientific_impl(first, last, value);
             case chars_format::hex:
                 return to_chars_hex_impl(first, last, value, local_precision); // LCOV_EXCL_LINE unreachable
         }

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -311,6 +311,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_scientific_impl(char* first, char* last, c
 
     // Use an offset of one since we need to insert the decimal point
     const auto significant_digits {std::numeric_limits<TargetDecimalType>::digits10 - trailing_zeros.number_of_removed_zeros};
+    exp += significant_digits - 1;
     BOOST_DECIMAL_ASSERT(significant_digits != 0); // Should have been filtered out
 
     // If there is only one digit, and we don't need any fractional part

--- a/include/boost/decimal/charconv.hpp
+++ b/include/boost/decimal/charconv.hpp
@@ -192,7 +192,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_nonfinite(char* first, char* last, const T
             {
                 if (buffer_len >= 7 + local_precision + 1)
                 {
-                    if (local_precision == 0)
+                    if (local_precision <= 0)
                     {
                         *first++ = '0';
                     }
@@ -201,7 +201,7 @@ BOOST_DECIMAL_CONSTEXPR auto to_chars_nonfinite(char* first, char* last, const T
                         boost::decimal::detail::memcpy(first, "0.0", 3U);
                         first += 3U;
 
-                        if (local_precision != -1 && local_precision != 1)
+                        if (local_precision != 1)
                         {
                             boost::decimal::detail::memset(first, '0', static_cast<std::size_t>(local_precision - 1));
                             first += local_precision - 1;

--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -38,6 +38,8 @@
 #include <boost/decimal/detail/div_impl.hpp>
 #include <boost/decimal/detail/cmath/next.hpp>
 #include "detail/int128.hpp"
+#include <boost/decimal/detail/to_chars_result.hpp>
+#include <boost/decimal/detail/chars_format.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 
@@ -86,6 +88,9 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE int128::uint128_t d128_biggest_no_combination_s
 
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t     d128_max_biased_exponent {UINT64_C(12287)};
 BOOST_DECIMAL_CONSTEXPR_VARIABLE int128::uint128_t d128_max_significand_value {UINT64_C(0b1111011010000100110111110101011011000011111000000), UINT64_C(0b0011011110001101100011100110001111111111111111111111111111111111)};
+
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 } //namespace detail
 
@@ -184,6 +189,9 @@ private:
 
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
+
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 public:
     // 3.2.4.1 construct/copy/destroy

--- a/include/boost/decimal/decimal128.hpp
+++ b/include/boost/decimal/decimal128.hpp
@@ -40,6 +40,7 @@
 #include "detail/int128.hpp"
 #include <boost/decimal/detail/to_chars_result.hpp>
 #include <boost/decimal/detail/chars_format.hpp>
+#include <boost/decimal/detail/components.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 
@@ -90,7 +91,7 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t     d128_max_biased_exponent {UIN
 BOOST_DECIMAL_CONSTEXPR_VARIABLE int128::uint128_t d128_max_significand_value {UINT64_C(0b1111011010000100110111110101011011000011111000000), UINT64_C(0b0011011110001101100011100110001111111111111111111111111111111111)};
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
-constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
+constexpr auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 } //namespace detail
 

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -134,6 +134,9 @@ private:
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
 
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
+
 public:
     constexpr decimal_fast128_t() noexcept = default;
 

--- a/include/boost/decimal/decimal128_fast.hpp
+++ b/include/boost/decimal/decimal128_fast.hpp
@@ -75,6 +75,11 @@ private:
         return static_cast<biased_exponent_type>(exponent_) - detail::bias_v<decimal128_t>;
     }
 
+    constexpr auto to_components() const noexcept -> detail::decimal_fast128_t_components
+    {
+        return {full_significand(), biased_exponent(), isneg()};
+    }
+
     template <typename Decimal, typename TargetType>
     friend constexpr auto to_integral_128(Decimal val) noexcept
         BOOST_DECIMAL_REQUIRES_TWO_RETURN(detail::is_decimal_floating_point_v, Decimal, detail::is_integral_v, TargetType, TargetType);

--- a/include/boost/decimal/decimal32.hpp
+++ b/include/boost/decimal/decimal32.hpp
@@ -39,6 +39,8 @@
 #include <boost/decimal/detail/promote_significand.hpp>
 #include <boost/decimal/detail/components.hpp>
 #include <boost/decimal/detail/cmath/next.hpp>
+#include <boost/decimal/detail/to_chars_result.hpp>
+#include <boost/decimal/detail/chars_format.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 
@@ -90,6 +92,9 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint32_t d32_biggest_no_combination_signif
 
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint32_t d32_max_biased_exponent = UINT32_C(191);
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint32_t d32_max_significand_value = UINT32_C(9'999'999);
+
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+constexpr auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 } // namespace detail
 
@@ -191,6 +196,9 @@ private:
 
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
+
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 public:
     // 3.2.2.1 construct/copy/destroy:

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -133,6 +133,9 @@ private:
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
 
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, const chars_format fmt) noexcept -> to_chars_result;
+
 public:
     constexpr decimal_fast32_t() noexcept = default;
 

--- a/include/boost/decimal/decimal32_fast.hpp
+++ b/include/boost/decimal/decimal32_fast.hpp
@@ -71,6 +71,11 @@ private:
         return static_cast<biased_exponent_type>(exponent_) - detail::bias_v<decimal32_t>;
     }
 
+    constexpr auto to_components() const noexcept -> detail::decimal_fast32_t_components
+    {
+        return {full_significand(), biased_exponent(), isneg()};
+    }
+
     friend constexpr auto div_impl(decimal_fast32_t lhs, decimal_fast32_t rhs, decimal_fast32_t& q, decimal_fast32_t& r) noexcept -> void;
 
     friend constexpr auto mod_impl(decimal_fast32_t lhs, decimal_fast32_t rhs, const decimal_fast32_t& q, decimal_fast32_t& r) noexcept -> void;

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -93,7 +93,7 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t d64_max_significand_value = UINT6
 
 
 template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
-constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
+constexpr auto to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 } //namespace detail
 

--- a/include/boost/decimal/decimal64.hpp
+++ b/include/boost/decimal/decimal64.hpp
@@ -41,6 +41,8 @@
 #include <boost/decimal/detail/promote_significand.hpp>
 #include <boost/decimal/detail/components.hpp>
 #include <boost/decimal/detail/cmath/next.hpp>
+#include <boost/decimal/detail/chars_format.hpp>
+#include <boost/decimal/detail/to_chars_result.hpp>
 
 #ifndef BOOST_DECIMAL_BUILD_MODULE
 
@@ -88,6 +90,10 @@ BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t d64_biggest_no_combination_signif
 
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t d64_max_biased_exponent = UINT64_C(767);
 BOOST_DECIMAL_CONSTEXPR_VARIABLE std::uint64_t d64_max_significand_value = UINT64_C(9'999'999'999'999'999);
+
+
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 } //namespace detail
 
@@ -195,6 +201,9 @@ private:
 
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
+
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
 
 public:
     // 3.2.3.1 construct/copy/destroy

--- a/include/boost/decimal/decimal64_fast.hpp
+++ b/include/boost/decimal/decimal64_fast.hpp
@@ -139,6 +139,9 @@ private:
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
     friend constexpr auto detail::nextafter_impl(DecimalType val, bool direction) noexcept -> DecimalType;
 
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE TargetDecimalType>
+    friend constexpr auto detail::to_chars_scientific_impl(char* first, char* last, const TargetDecimalType& value, chars_format fmt) noexcept -> to_chars_result;
+
 public:
     constexpr decimal_fast64_t() noexcept = default;
 

--- a/include/boost/decimal/decimal64_fast.hpp
+++ b/include/boost/decimal/decimal64_fast.hpp
@@ -74,6 +74,11 @@ private:
         return static_cast<biased_exponent_type>(exponent_) - detail::bias_v<decimal64_t>;
     }
 
+    constexpr auto to_components() const noexcept -> detail::decimal_fast64_t_components
+    {
+        return {full_significand(), biased_exponent(), isneg()};
+    }
+
     // Equality template between any integer type and decimal32_t
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE Decimal, BOOST_DECIMAL_INTEGRAL Integer>
     friend constexpr auto mixed_equality_impl(Decimal lhs, Integer rhs) noexcept


### PR DESCRIPTION
Closes: #1009 

Provides up to 40% performance improvement (decimal_fast128_t) with non-zero improvements across the board