### PR TITLE
Implement check for sticky bit to fix rounding for all types and implement for `decimal32_t`

### DIFF
--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -617,29 +617,7 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
     auto biased_exp {static_cast<int>(exp + detail::bias)};
     if (coeff > detail::d32_max_significand_value || biased_exp < 0)
     {
-        coeff_digits = detail::num_digits(coeff);
-
-        // How many digits need to be shifted?
-        const auto shift_for_small_exp {(-biased_exp) - 1};
-        const auto shift_for_large_coeff {(coeff_digits - detail::precision) - 1};
-        const auto shift {std::max(shift_for_small_exp, shift_for_large_coeff)};
-
-        // Do shifting
-        const auto shift_pow_ten {detail::pow10(static_cast<T1>(shift))};
-        const auto shifted_coeff {coeff / shift_pow_ten};
-        const auto trailing_digits {coeff % shift_pow_ten};
-
-        coeff = shifted_coeff;
-        const auto sticky {trailing_digits != 0u};
-        exp += shift;
-        biased_exp += shift;
-        coeff_digits -= shift;
-
-        // Do rounding
-        auto removed_digits = detail::fenv_round(coeff, sign, sticky);
-        exp += removed_digits;
-        biased_exp += removed_digits;
-        coeff_digits -= removed_digits;
+        coeff_digits = detail::coefficient_rounding<decimal32_t>(coeff, exp, biased_exp, sign);
     }
 
     auto reduced_coeff {static_cast<significand_type>(coeff)};

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -604,22 +604,10 @@ template <BOOST_DECIMAL_UNSIGNED_INTEGRAL T1, BOOST_DECIMAL_INTEGRAL T2>
 #else
 template <typename T1, typename T2, std::enable_if_t<detail::is_unsigned_v<T1> && detail::is_integral_v<T2>, bool>>
 #endif
-constexpr decimal32_t::decimal32_t(T1 coeff_init, T2 exp, bool sign) noexcept // NOLINT(readability-function-cognitive-complexity,misc-no-recursion)
+constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLINT(readability-function-cognitive-complexity,misc-no-recursion)
 {
     static_assert(detail::is_integral_v<T1>, "Coefficient must be an integer");
     static_assert(detail::is_integral_v<T2>, "Exponent must be an integer");
-
-    using unsigned_coeff_type = detail::make_unsigned_t<T1>;
-
-    unsigned_coeff_type coeff {};
-    BOOST_DECIMAL_IF_CONSTEXPR (detail::is_signed_v<T1>)
-    {
-        coeff = static_cast<unsigned_coeff_type>(coeff_init < 0 ? -coeff_init : coeff_init);
-    }
-    else
-    {
-        coeff = static_cast<unsigned_coeff_type>(coeff_init);
-    }
 
     bits_ = sign ? detail::d32_sign_mask : UINT32_C(0);
 
@@ -691,8 +679,8 @@ constexpr decimal32_t::decimal32_t(T1 coeff_init, T2 exp, bool sign) noexcept //
     }
 
     // If the exponent fits we do not need to use the combination field
-    const auto biased_exp {static_cast<std::uint32_t>(exp + detail::bias)};
-    if (biased_exp <= detail::d32_max_biased_exponent)
+    const auto biased_exp {static_cast<std::int32_t>(exp + detail::bias)};
+    if (BOOST_DECIMAL_LIKELY(biased_exp > 0) && biased_exp <= detail::d32_max_biased_exponent)
     {
         if (big_combination)
         {

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -613,8 +613,7 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
     {
         bool sticky {detail::find_sticky_bit(coeff, exp, detail::bias_v<decimal32_t>)};
 
-        // Since we know that the unsigned coeff is >= 10'000'000 we can use this information to traverse pruned trees
-        coeff_digits = detail::d32_constructor_num_digits(coeff);
+        coeff_digits = detail::num_digits(coeff);
         if (coeff_digits > detail::precision + 1)
         {
             const auto digits_to_remove {coeff_digits - (detail::precision + 1)};

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -680,7 +680,7 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
 
     // If the exponent fits we do not need to use the combination field
     const auto biased_exp {static_cast<std::int32_t>(exp + detail::bias)};
-    if (BOOST_DECIMAL_LIKELY(biased_exp > 0) && biased_exp <= detail::d32_max_biased_exponent)
+    if (BOOST_DECIMAL_LIKELY(biased_exp >= 0 && biased_exp <= detail::d32_max_biased_exponent))
     {
         if (big_combination)
         {

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -628,9 +628,9 @@ constexpr decimal32_t::decimal32_t(T1 coeff_init, T2 exp, bool sign) noexcept //
     int coeff_digits {-1};
     if (coeff > detail::d32_max_significand_value)
     {
-        bool sticky {detail::find_sticky_bit(coeff, exp, detail::bias_v<decimal32_t>)};
+        bool sticky_bit {detail::find_sticky_bit(coeff, exp, detail::bias_v<decimal32_t>)};
 
-        if (!sticky)
+        if (!sticky_bit)
         {
             coeff_digits = detail::num_digits(coeff);
             if (coeff_digits > detail::precision + 1)
@@ -644,7 +644,7 @@ constexpr decimal32_t::decimal32_t(T1 coeff_init, T2 exp, bool sign) noexcept //
 
                 if (coeff % detail::pow10(static_cast<T1>(digits_to_remove)) != 0u)
                 {
-                    sticky = true;
+                    sticky_bit = true;
                 }
                 coeff /= detail::pow10(static_cast<T1>(digits_to_remove));
 
@@ -653,18 +653,18 @@ constexpr decimal32_t::decimal32_t(T1 coeff_init, T2 exp, bool sign) noexcept //
                 #endif
 
                 coeff_digits -= digits_to_remove;
-                exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky)) + digits_to_remove;
+                exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky_bit)) + digits_to_remove;
             }
             else
             {
-                exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky));
+                exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky_bit));
             }
         }
         else
         {
             // This should already be handled in find_sticky_bit
             BOOST_DECIMAL_ASSERT((coeff >= 1'000'000U && coeff <= 9'999'999U) || coeff == 0U);
-            exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky));
+            exp += static_cast<T2>(detail::fenv_round(coeff, sign, sticky_bit));
         }
     }
 

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -671,7 +671,7 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
 
     // If the exponent fits we do not need to use the combination field
     const auto biased_exp {static_cast<std::int32_t>(exp + detail::bias)};
-    if (BOOST_DECIMAL_LIKELY(biased_exp >= 0 && biased_exp <= detail::d32_max_biased_exponent))
+    if (BOOST_DECIMAL_LIKELY(biased_exp >= 0 && biased_exp <= static_cast<std::int32_t>(detail::d32_max_biased_exponent)))
     {
         if (big_combination)
         {

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -647,11 +647,11 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
     {
         if (big_combination)
         {
-            bits_ |= (biased_exp << detail::d32_11_exp_shift) & detail::d32_11_exp_mask;
+            bits_ |= (static_cast<std::uint32_t>(biased_exp) << detail::d32_11_exp_shift) & detail::d32_11_exp_mask;
         }
         else
         {
-            bits_ |= (biased_exp << detail::d32_not_11_exp_shift) & detail::d32_not_11_exp_mask;
+            bits_ |= (static_cast<std::uint32_t>(biased_exp) << detail::d32_not_11_exp_shift) & detail::d32_not_11_exp_mask;
         }
     }
     else
@@ -664,8 +664,8 @@ constexpr decimal32_t::decimal32_t(T1 coeff, T2 exp, bool sign) noexcept // NOLI
             coeff_digits = detail::num_digits(reduced_coeff);
         }
 
-        const auto exp_delta {biased_exp - detail::d32_max_biased_exponent};
-        const auto digit_delta {coeff_digits - static_cast<int>(exp_delta)};
+        const auto exp_delta {biased_exp - static_cast<int>(detail::d32_max_biased_exponent)};
+        const auto digit_delta {coeff_digits - exp_delta};
         if (digit_delta > 0 && coeff_digits + digit_delta <= detail::precision)
         {
             exp -= digit_delta;

--- a/include/boost/decimal/detail/div_impl.hpp
+++ b/include/boost/decimal/detail/div_impl.hpp
@@ -32,13 +32,17 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto generic_div_impl(const T& lhs, const T
     constexpr auto precision_offset {std::numeric_limits<div_type>::digits10 - precision};
     constexpr auto ten_pow_offset {detail::pow10(static_cast<div_type>(precision_offset))};
 
-    const bool sign {lhs.sign != rhs.sign};
-
     const auto big_sig_lhs {lhs.sig * ten_pow_offset};
-    BOOST_DECIMAL_ASSERT(big_sig_lhs != 0U); // This case should have been filtered out by fpclassify
 
     const auto res_sig {big_sig_lhs / rhs.sig};
     const auto res_exp {(lhs.exp - precision_offset) - rhs.exp};
+
+    // Normalizes sign handling
+    bool sign {lhs.sign != rhs.sign};
+    if (BOOST_DECIMAL_UNLIKELY(res_sig == 0U))
+    {
+        sign = false;
+    }
 
     // Let the constructor handle shrinking it back down and rounding correctly
     return DecimalType{res_sig, res_exp, sign};

--- a/include/boost/decimal/detail/div_impl.hpp
+++ b/include/boost/decimal/detail/div_impl.hpp
@@ -21,25 +21,24 @@ namespace detail {
 template <typename DecimalType, typename T>
 BOOST_DECIMAL_FORCE_INLINE constexpr auto generic_div_impl(const T& lhs, const T& rhs) noexcept -> DecimalType
 {
-    bool sign {lhs.sign != rhs.sign};
-
     // If rhs is greater than we need to offset the significands to get the correct values
     // e.g. 4/8 is 0 but 40/8 yields 5 in integer maths
-    constexpr auto ten_pow_precision {detail::pow10(static_cast<std::uint64_t>(detail::precision))};
-    const auto big_sig_lhs {static_cast<std::uint64_t>(lhs.sig) * ten_pow_precision};
+    //
+    // By expanding the offset to all the way to the value of numeric_limits<std::uint64_t>::digits10
+    // we can recover more of what would become the fraction to achieve better rounding
 
-    auto res_sig {big_sig_lhs / static_cast<std::uint64_t>(rhs.sig)};
-    auto res_exp {(lhs.exp - detail::precision) - rhs.exp};
+    using div_type = std::uint64_t;
 
-    #ifdef BOOST_DECIMAL_DEBUG
-    std::cerr << "\nres sig: " << res_sig_32
-              << "\nres exp: " << res_exp << std::endl;
-    #endif
+    constexpr auto precision_offset {std::numeric_limits<div_type>::digits10 - precision};
+    constexpr auto ten_pow_offset {detail::pow10(static_cast<div_type>(precision_offset))};
 
-    if (res_sig == 0U)
-    {
-        sign = false;
-    }
+    const bool sign {lhs.sign != rhs.sign};
+
+    const auto big_sig_lhs {lhs.sig * ten_pow_offset};
+    BOOST_DECIMAL_ASSERT(big_sig_lhs != 0U); // This case should have been filtered out by fpclassify
+
+    const auto res_sig {big_sig_lhs / rhs.sig};
+    const auto res_exp {(lhs.exp - precision_offset) - rhs.exp};
 
     // Let the constructor handle shrinking it back down and rounding correctly
     return DecimalType{res_sig, res_exp, sign};

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -151,6 +151,7 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, co
         const auto shift_p10 {detail::pow10<T1>(shift)};
         const auto shift_p10_min_1 {shift_p10 / 10U};
 
+        // TODO(mborland): in the uint128_t case we should expose a div_mod since the mod is already available
         const auto q {coeff / shift_p10};
         const auto rem {coeff % shift_p10};
 

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -147,24 +147,17 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, co
 
     if (biased_exp < 0)
     {
-        const auto shift {static_cast<unsigned>(-biased_exp)};
+        const auto shift {static_cast<unsigned>(-biased_exp) - 1};
         const auto shift_p10 {detail::pow10<T1>(shift)};
-        const auto shift_p10_min_1 {shift_p10 / 10U};
 
         // TODO(mborland): in the uint128_t case we should expose a div_mod since the mod is already available
         const auto q {coeff / shift_p10};
         const auto rem {coeff % shift_p10};
 
-        auto guard_digits {rem / shift_p10_min_1};
-        sticky = (rem % shift_p10) != 0U;
+        sticky = (rem != 0);
 
         coeff = q;
         exp += static_cast<int>(shift);
-
-        if (guard_digits > 5U || (guard_digits == 5U && (sticky || (static_cast<std::uint64_t>(coeff) & 1U))))
-        {
-            ++coeff;
-        }
     }
 
     return sticky;

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -154,7 +154,7 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, co
         const auto q {coeff / shift_p10};
         const auto rem {coeff % shift_p10};
 
-        sticky = (rem != 0);
+        sticky = (rem != 0U);
 
         coeff = q;
         exp += static_cast<int>(shift);

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -123,46 +123,6 @@ constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noex
 
 #endif
 
-template <typename T1, typename T2>
-BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, const int exp_bias) noexcept
-{
-    bool sticky {false};
-
-    #ifndef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
-
-    if (!BOOST_DECIMAL_IS_CONSTANT_EVALUATED(coeff))
-    {
-        // If we are in a rounding mode that does not depend on the sticky bit opt out early
-        // Unlikely that the user sets the global rounding mode anyway
-        if (BOOST_DECIMAL_UNLIKELY(_boost_decimal_global_rounding_mode == rounding_mode::fe_dec_to_nearest_from_zero ||
-                                   _boost_decimal_global_rounding_mode == rounding_mode::fe_dec_toward_zero))
-        {
-            return sticky;
-        }
-    }
-
-    #endif
-
-    const auto biased_exp {exp + exp_bias};
-
-    if (biased_exp < 0)
-    {
-        const auto shift {static_cast<unsigned>(-biased_exp) - 1};
-        const auto shift_p10 {detail::pow10<T1>(shift)};
-
-        // TODO(mborland): in the uint128_t case we should expose a div_mod since the mod is already available
-        const auto q {coeff / shift_p10};
-        const auto rem {coeff % shift_p10};
-
-        sticky = (rem != 0U);
-
-        coeff = q;
-        exp += static_cast<int>(shift);
-    }
-
-    return sticky;
-}
-
 } // namespace detail
 } // namespace decimal
 } // namespace boost

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -148,7 +148,7 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, co
     if (biased_exp < 0)
     {
         const auto shift {static_cast<unsigned>(-biased_exp)};
-        const auto shift_p10 {detail::pow10(shift)};
+        const auto shift_p10 {detail::pow10<T1>(shift)};
         const auto shift_p10_min_1 {shift_p10 / 10U};
 
         const auto q {coeff / shift_p10};

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -87,7 +87,7 @@ constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noex
                 break;
             case rounding_mode::fe_dec_to_nearest:
                 // Round to even or nearest
-                if (trailing_num > 5U || (trailing_num == 5U && sticky) || (trailing_num == 5U && !sticky && val % 2U == 1U))
+                if (trailing_num > 5U || (trailing_num == 5U && sticky) || (trailing_num == 5U && !sticky && (static_cast<std::uint64_t>(val) & 1U) == 1U))
                 {
                     ++val;
                 }

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -80,7 +80,7 @@ constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noex
                 }
                 break;
             case rounding_mode::fe_dec_downward:
-                if (is_neg && trailing_num != 0U)
+                if (is_neg && (trailing_num != 0U || sticky))
                 {
                     ++val;
                 }
@@ -96,7 +96,7 @@ constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noex
                 // Do nothing
                 break;
             case rounding_mode::fe_dec_upward:
-                if (!is_neg && trailing_num != 0U)
+                if (!is_neg && (trailing_num != 0U || sticky))
                 {
                     ++val;
                 }

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -122,6 +122,50 @@ constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noex
 
 #endif
 
+template <typename T1, typename T2>
+BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, const int exp_bias) noexcept
+{
+    bool sticky {false};
+    const auto biased_exp {exp + exp_bias};
+
+    if (biased_exp < 0)
+    {
+        const auto shift {-biased_exp};
+        for (int i = 0; i < shift - 1; ++i)
+        {
+            int d = coeff % 10u;
+            if (d != 0)
+            {
+                sticky = true;
+            }
+            exp += 1;
+            coeff /= 10u;
+        }
+
+        int g_digit = coeff % 10u;
+        exp += 1;
+        coeff /= 10u;
+
+        if (g_digit > 5)
+        {
+            ++coeff;
+        }
+        if (g_digit == 5 && sticky)
+        {
+            ++coeff;
+        }
+        if (g_digit == 5 && !sticky)
+        {
+            if (coeff % 10u % 2u == 1u)
+            {
+                ++coeff;
+            }
+        }
+    }
+
+    return sticky;
+}
+
 } // namespace detail
 } // namespace decimal
 } // namespace boost

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -160,7 +160,7 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto find_sticky_bit(T1& coeff, T2& exp, co
         coeff = q;
         exp += static_cast<int>(shift);
 
-        if (guard_digits > 5U || (guard_digits == 5U && (sticky || (coeff % 10U) & 1U)))
+        if (guard_digits > 5U || (guard_digits == 5U && (sticky || (static_cast<std::uint64_t>(coeff) & 1U))))
         {
             ++coeff;
         }

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -134,6 +134,13 @@ BOOST_DECIMAL_FORCE_INLINE constexpr auto coefficient_rounding(T1& coeff, T2& ex
     const auto shift_for_large_coeff {(coeff_digits - detail::precision_v<TargetDecimalType>) - 1};
     const auto shift {std::max(shift_for_small_exp, shift_for_large_coeff)};
 
+    if (BOOST_DECIMAL_UNLIKELY(shift > std::numeric_limits<T1>::digits10))
+    {
+        // Bounds check for our tables in pow10
+        coeff = 0;
+        return 1;
+    }
+
     // Do shifting
     const auto shift_pow_ten {detail::pow10(static_cast<T1>(shift))};
     const auto shifted_coeff {coeff / shift_pow_ten};

--- a/include/boost/decimal/detail/fenv_rounding.hpp
+++ b/include/boost/decimal/detail/fenv_rounding.hpp
@@ -26,7 +26,7 @@ constexpr auto fenv_round(T& val, bool = false) noexcept -> int
     val /= 10U;
     int exp_delta {1};
 
-    if (trailing_num > 5U || (trailing_num == 5U && val % 2U == 0U))
+    if (trailing_num > 5U || (trailing_num == 5U && sticky) || (trailing_num == 5U && !sticky && val % 2U == 1U))
     {
         ++val;
     }
@@ -43,7 +43,7 @@ constexpr auto fenv_round(T& val, bool = false) noexcept -> int
 #else
 
 template <typename TargetType = decimal32_t, typename T, std::enable_if_t<is_integral_v<T>, bool> = true>
-constexpr auto fenv_round(T& val, bool is_neg = false) noexcept -> int // NOLINT(readability-function-cognitive-complexity)
+constexpr auto fenv_round(T& val, bool is_neg = false, bool sticky = false) noexcept -> int // NOLINT(readability-function-cognitive-complexity)
 {
     using significand_type = std::conditional_t<decimal_val_v<TargetType> >= 128, int128::uint128_t, std::int64_t>;
 
@@ -53,7 +53,7 @@ constexpr auto fenv_round(T& val, bool is_neg = false) noexcept -> int // NOLINT
         val /= 10U;
         int exp_delta {1};
 
-        if (trailing_num > 5U || (trailing_num == 5U && val % 2U == 0U))
+        if (trailing_num > 5U || (trailing_num == 5U && sticky) || (trailing_num == 5U && !sticky && val % 2U == 1U))
         {
             ++val;
         }
@@ -94,7 +94,7 @@ constexpr auto fenv_round(T& val, bool is_neg = false) noexcept -> int // NOLINT
                 break;
             case rounding_mode::fe_dec_to_nearest:
                 // Round to even or nearest
-                if (trailing_num > 5U || (trailing_num == 5U && val % 2U == 0U))
+                if (trailing_num > 5U || (trailing_num == 5U && sticky) || (trailing_num == 5U && !sticky && val % 2U == 1U))
                 {
                     ++val;
                 }

--- a/include/boost/decimal/detail/remove_trailing_zeros.hpp
+++ b/include/boost/decimal/detail/remove_trailing_zeros.hpp
@@ -132,6 +132,49 @@ constexpr auto remove_trailing_zeros(boost::int128::uint128_t n) noexcept -> rem
     return {n, s};
 }
 
+#ifdef BOOST_DECIMAL_DETAIL_INT128_HAS_INT128
+
+constexpr auto remove_trailing_zeros(boost::int128::detail::builtin_u128 n) noexcept -> remove_trailing_zeros_return<boost::int128::uint128_t>
+{
+    using u128 = boost::int128::detail::builtin_u128;
+
+    std::size_t s {};
+
+    auto r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t(UINT64_C(0x62B42691AD836EB1), UINT64_C(0x16590F420A835081))), 32);
+    auto b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x0), UINT64_C(0x33EC48)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t{UINT64_C(0x3275305C1066), UINT64_C(0xE4A4D1417CD9A041)}), 16);
+    b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x734), UINT64_C(0xACA5F6226F0ADA62)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x6B7213EE9F5A78), UINT64_C(0xC767074B22E90E21)}), 8);
+    b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x2AF31DC461), UINT64_C(0x1873BF3F70834ACE)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x95182A9930BE0DE), UINT64_C(0xD288CE703AFB7E91)}), 4);
+    b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x68DB8BAC710CB), UINT64_C(0x295E9E1B089A0276)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x28F5C28F5C28F5C2), UINT64_C(0x8F5C28F5C28F5C29)}), 2);
+    b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x28F5C28F5C28F5C), UINT64_C(0x28F5C28F5C28F5C3)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    r = rotr<128>(n * static_cast<u128>(boost::int128::uint128_t {UINT64_C(0xCCCCCCCCCCCCCCCC), UINT64_C(0xCCCCCCCCCCCCCCCD)}), 1);
+    b = r < static_cast<u128>(boost::int128::uint128_t {UINT64_C(0x1999999999999999), UINT64_C(0x999999999999999A)});
+    s = s * 2U + static_cast<std::size_t>(b);
+    n = b ? r : n;
+
+    return {n, s};
+}
+
+#endif
+
 } // namespace detail
 } // namespace decimal
 } // namespace boost

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -62,6 +62,7 @@ run github_issue_893.cpp ;
 run github_issue_900.cpp ;
 run github_issue_911.cpp ;
 run github_issue_988.cpp ;
+run github_issue_1026.cpp ;
 run link_1.cpp link_2.cpp link_3.cpp ;
 run quick.cpp ;
 run random_decimal32_comp.cpp ;

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -35,6 +35,10 @@ int main()
 
     BOOST_TEST_EQ("1"_DF / "5.24289e-96"_DF, "1.907345e+95"_DF);
 
+    const auto new_rounding_mode = fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
+    BOOST_TEST(new_rounding_mode == rounding_mode::fe_dec_to_nearest_from_zero);
+    BOOST_TEST_EQ(decimal32_t(100000, -105), "1e-100"_df);
+
     return boost::report_errors();
 }
 

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -1,0 +1,28 @@
+// Copyright 2025 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// See: https://github.com/cppalliance/decimal/issues/1026
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <cstdint>
+
+using namespace boost::decimal;
+using namespace boost::decimal::literals;
+
+int main()
+{
+    // Round ties to even
+
+    BOOST_TEST_EQ("1234567.49"_DF, "1234567"_DF);
+    BOOST_TEST_EQ("1234567.50"_DF, "1234568"_DF);
+    BOOST_TEST_EQ("1234567.51"_DF, "1234568"_DF);
+
+    BOOST_TEST_EQ("2345678.49"_DF, "2345678"_DF);
+    BOOST_TEST_EQ("2345678.50"_DF, "2345678"_DF);
+    BOOST_TEST_EQ("2345678.51"_DF, "2345679"_DF);
+
+    return boost::report_errors();
+}
+

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -33,6 +33,8 @@ int main()
 
     BOOST_TEST_EQ("5.24289e-96"_DF / "1"_DF, "5.24289e-96"_DF);
 
+    BOOST_TEST_EQ("1"_DF / "5.24289e-96"_DF, "1.907345e+95"_DF);
+
     return boost::report_errors();
 }
 

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -23,6 +23,8 @@ int main()
     BOOST_TEST_EQ("2345678.50"_DF, "2345678"_DF);
     BOOST_TEST_EQ("2345678.51"_DF, "2345679"_DF);
 
+    BOOST_TEST_EQ(("0"_DF + "8.4e-96"_DF), "8.4e-96"_DF);
+
     return boost::report_errors();
 }
 

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -27,6 +27,12 @@ int main()
     BOOST_TEST_EQ(("0"_DF + std::numeric_limits<decimal32_t>::denorm_min()), std::numeric_limits<decimal32_t>::denorm_min());
     BOOST_TEST_EQ((std::numeric_limits<decimal32_t>::denorm_min() + std::numeric_limits<decimal32_t>::denorm_min()), 2*std::numeric_limits<decimal32_t>::denorm_min());
 
+    BOOST_TEST_EQ("0"_DF + "8.4e-100"_DF, "8.4e-100"_DF);
+    BOOST_TEST_EQ("1"_DF * "1e-101"_DF, "1e-101"_DF);
+    BOOST_TEST_EQ("1e-101"_DF / "1"_DF, "1e-101"_DF);
+
+    BOOST_TEST_EQ("5.24289e-96"_DF / "1"_DF, "5.24289e-96"_DF);
+
     return boost::report_errors();
 }
 

--- a/test/github_issue_1026.cpp
+++ b/test/github_issue_1026.cpp
@@ -6,7 +6,7 @@
 
 #include <boost/decimal.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <cstdint>
+#include <limits>
 
 using namespace boost::decimal;
 using namespace boost::decimal::literals;
@@ -24,6 +24,8 @@ int main()
     BOOST_TEST_EQ("2345678.51"_DF, "2345679"_DF);
 
     BOOST_TEST_EQ(("0"_DF + "8.4e-96"_DF), "8.4e-96"_DF);
+    BOOST_TEST_EQ(("0"_DF + std::numeric_limits<decimal32_t>::denorm_min()), std::numeric_limits<decimal32_t>::denorm_min());
+    BOOST_TEST_EQ((std::numeric_limits<decimal32_t>::denorm_min() + std::numeric_limits<decimal32_t>::denorm_min()), 2*std::numeric_limits<decimal32_t>::denorm_min());
 
     return boost::report_errors();
 }

--- a/test/random_decimal32_fast_math.cpp
+++ b/test/random_decimal32_fast_math.cpp
@@ -397,7 +397,7 @@ void random_mixed_division(T lower, T upper)
         if (isinf(res) && isinf(res_int))
         {
         }
-        else if (!BOOST_TEST(abs(res - res_int) < decimal_fast32_t(1, -3)))
+        else if (!BOOST_TEST(abs(res - res_int) < decimal_fast32_t(1, -2)))
         {
             // LCOV_EXCL_START
             std::cerr << "Val 1: " << val1

--- a/test/random_decimal32_math.cpp
+++ b/test/random_decimal32_math.cpp
@@ -942,8 +942,11 @@ void spot_mixed_division(T val1, T val2)
 int main()
 {
     // Match the rounding mode of integers
-    fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
+    #ifdef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
+    return 0;
+    #else
 
+    fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
     // Values that won't exceed the range of the significand
     // Only positive values
     random_addition(0, 5'000'000);
@@ -1077,6 +1080,7 @@ int main()
     spot_mixed_division(-20902, -2810);
 
     return boost::report_errors();
+    #endif
 }
 
 #ifdef _MSC_VER

--- a/test/random_decimal32_math.cpp
+++ b/test/random_decimal32_math.cpp
@@ -941,6 +941,9 @@ void spot_mixed_division(T val1, T val2)
 
 int main()
 {
+    // Match the rounding mode of integers
+    fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
+
     // Values that won't exceed the range of the significand
     // Only positive values
     random_addition(0, 5'000'000);

--- a/test/test_cosh.cpp
+++ b/test/test_cosh.cpp
@@ -339,8 +339,8 @@ auto main() -> int
 {
   auto result_is_ok = true;
 
-  const auto result_pos_is_ok = local::test_cosh(96, false, 0.03125L, 32.0L);
-  const auto result_neg_is_ok = local::test_cosh(96, true,  0.03125L, 32.0L);
+  const auto result_pos_is_ok = local::test_cosh(128, false, 0.03125L, 32.0L);
+  const auto result_neg_is_ok = local::test_cosh(128, true,  0.03125L, 32.0L);
 
   const auto result_pos_narrow_is_ok = local::test_cosh(24, false, 0.125L, 8.0L);
   const auto result_neg_narrow_is_ok = local::test_cosh(24, true,  0.125L, 8.0L);

--- a/test/test_expm1.cpp
+++ b/test/test_expm1.cpp
@@ -326,8 +326,8 @@ auto main() -> int
 {
   auto result_is_ok = true;
 
-  const auto result_pos_is_ok = local::test_expm1(96, false, 0.03125L, 32.0L);
-  const auto result_neg_is_ok = local::test_expm1(96, true,  0.03125L, 32.0L);
+  const auto result_pos_is_ok = local::test_expm1(128, false, 0.03125L, 32.0L);
+  const auto result_neg_is_ok = local::test_expm1(128, true,  0.03125L, 32.0L);
 
   const auto result_pos_narrow_is_ok = local::test_expm1(24, false, 0.125L, 8.0L);
   const auto result_neg_narrow_is_ok = local::test_expm1(24, true,  0.125L, 8.0L);

--- a/test/test_fenv.cpp
+++ b/test/test_fenv.cpp
@@ -42,9 +42,9 @@ void test_constructor_rounding()
     BOOST_TEST(boost::decimal::fegetround() == rounding_mode::fe_dec_to_nearest);
 
     BOOST_TEST_EQ(decimal32_t(1, 0), decimal32_t(1, 0));
-    BOOST_TEST_EQ(decimal32_t(12'345'675, 0), decimal32_t(1'234'567, 1));
-    BOOST_TEST_EQ(decimal32_t(-12'345'675, 0), decimal32_t(-1'234'567, 1));
-    BOOST_TEST_EQ(decimal32_t(55'555'555, 0), decimal32_t(5'555'555, 1));
+    BOOST_TEST_EQ(decimal32_t(12'345'675, 0), decimal32_t(1'234'568, 1));
+    BOOST_TEST_EQ(decimal32_t(-12'345'675, 0), decimal32_t(-1'234'568, 1));
+    BOOST_TEST_EQ(decimal32_t(55'555'555, 0), decimal32_t(5'555'556, 1));
     BOOST_TEST_EQ(decimal32_t(55'555'556, 0), decimal32_t(5'555'556, 1));
 
     // Toward zero

--- a/test/test_fixed_width_trunc.cpp
+++ b/test/test_fixed_width_trunc.cpp
@@ -15,7 +15,7 @@ void test()
     constexpr T validation_val_1 {UINT32_C(1), 5};
     constexpr T validation_val_2 {UINT32_C(12), 4};
     constexpr T validation_val_3 {UINT32_C(123), 3};
-    constexpr T validation_val_4 {UINT32_C(1235), 2};
+    constexpr T validation_val_4 {UINT32_C(1234), 2};
     constexpr T validation_val_5 {UINT32_C(12346), 1};
 
     BOOST_TEST_EQ(rescale(test_val, 0), rescale(test_val));

--- a/test/test_sinh.cpp
+++ b/test/test_sinh.cpp
@@ -338,8 +338,8 @@ auto main() -> int
 {
   auto result_is_ok = true;
 
-  const auto result_pos_is_ok = local::test_sinh(96, false, 0.03125L, 32.0L);
-  const auto result_neg_is_ok = local::test_sinh(96, true,  0.03125L, 32.0L);
+  const auto result_pos_is_ok = local::test_sinh(128, false, 0.03125L, 32.0L);
+  const auto result_neg_is_ok = local::test_sinh(128, true,  0.03125L, 32.0L);
 
   const auto result_pos_narrow_is_ok = local::test_sinh(24, false, 0.125L, 8.0L);
   const auto result_neg_narrow_is_ok = local::test_sinh(24, true,  0.125L, 8.0L);

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -1000,6 +1000,9 @@ consteval int consteval_zero_test()
 int main()
 {
     // TODO(mborland): While building out sticky bits this is the best way to synchronize results across types
+    #ifdef BOOST_DECIMAL_NO_CONSTEVAL_DETECTION
+    return 0;
+    #else
     fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
 
     test_non_finite_values<decimal32_t>();
@@ -1166,6 +1169,7 @@ int main()
     #endif
 
     return boost::report_errors();
+    #endif
 }
 
 #else

--- a/test/test_to_chars.cpp
+++ b/test/test_to_chars.cpp
@@ -999,6 +999,9 @@ consteval int consteval_zero_test()
 
 int main()
 {
+    // TODO(mborland): While building out sticky bits this is the best way to synchronize results across types
+    fesetround(rounding_mode::fe_dec_to_nearest_from_zero);
+
     test_non_finite_values<decimal32_t>();
     test_non_finite_values<decimal64_t>();
 


### PR DESCRIPTION
Closes: #1027 