### PR TITLE
Update coverage toolchain

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-﻿# ------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 #  Copyright Matt Borland 2023 - 2024.
 #  Copyright Christopher Kormanyos 2023 - 2024.
 #  Distributed under the Boost Software License,
@@ -17,14 +17,14 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   gcc-gcov-native:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        standard: [ c++20 ]
+        standard: [ c++2a ]
         compiler: [ g++ ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Should be able to run the `to_chars` runs which are hurting our coverage significantly