### PR TITLE
Remove deprecated macOS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,9 +289,6 @@ jobs:
 
           - toolset: clang
             cxxstd: "03,11,14,17,20,2b"
-            os: macos-13
-          - toolset: clang
-            cxxstd: "03,11,14,17,20,2b"
             os: macos-14
           - toolset: clang
             cxxstd: "03,11,14,17,20,2b"
@@ -572,7 +569,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-          - os: macos-13
           - os: macos-14
           - os: macos-15
 
@@ -620,7 +616,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-          - os: macos-13
           - os: macos-14
           - os: macos-15
 
@@ -678,7 +673,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-          - os: macos-13
           - os: macos-14
           - os: macos-15
 
@@ -734,7 +728,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-          - os: macos-13
           - os: macos-14
           - os: macos-15
 


### PR DESCRIPTION
See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/