### PR TITLE
Fix build on POWER10

### DIFF
--- a/include/boost/decimal/decimal128_t.hpp
+++ b/include/boost/decimal/decimal128_t.hpp
@@ -223,6 +223,10 @@ public:
     #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal128_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit constexpr decimal128_t(long double val) noexcept = delete;
+    #endif
+
     template <typename Float>
     BOOST_DECIMAL_CXX20_CONSTEXPR auto operator=(const Float& val) noexcept
         BOOST_DECIMAL_REQUIRES_RETURN(detail::is_floating_point_v, Float, decimal128_t&);

--- a/include/boost/decimal/decimal128_t.hpp
+++ b/include/boost/decimal/decimal128_t.hpp
@@ -282,7 +282,10 @@ public:
     // 3.2.6 Conversion to floating-point type
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;
@@ -943,10 +946,12 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal128_t::operator double() const noexcept
     return to_float<decimal128_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal128_t::operator long double() const noexcept
 {
     return to_float<decimal128_t, long double>(*this);
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal128_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -295,7 +295,10 @@ public:
     // 3.2.6 Conversion to floating-point type
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;
@@ -1876,11 +1879,13 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal32_t::operator double() const noexcept
     return to_float<decimal32_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal32_t::operator long double() const noexcept
 {
     // Double already has more range and precision than a decimal32_t will ever be able to provide
     return static_cast<long double>(to_float<decimal32_t, double>(*this));
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal32_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -229,6 +229,10 @@ public:
     #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal32_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit constexpr decimal32_t(long double val) noexcept = delete;
+    #endif
+
     template <typename Float>
     BOOST_DECIMAL_CXX20_CONSTEXPR auto operator=(const Float& val) noexcept
         BOOST_DECIMAL_REQUIRES_RETURN(detail::is_floating_point_v, Float, decimal32_t&);

--- a/include/boost/decimal/decimal64_t.hpp
+++ b/include/boost/decimal/decimal64_t.hpp
@@ -289,7 +289,10 @@ public:
     // 3.2.6 Conversion to a floating-point type
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;
@@ -856,10 +859,12 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_t::operator double() const noexcept
     return to_float<decimal64_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_t::operator long double() const noexcept
 {
     return to_float<decimal64_t, long double>(*this);
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal64_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal64_t.hpp
+++ b/include/boost/decimal/decimal64_t.hpp
@@ -241,6 +241,10 @@ public:
     #endif
     BOOST_DECIMAL_CXX20_CONSTEXPR decimal64_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit constexpr decimal64_t(long double val) noexcept = delete;
+    #endif
+
     template <typename Float>
     BOOST_DECIMAL_CXX20_CONSTEXPR auto operator=(const Float& val) noexcept
         BOOST_DECIMAL_REQUIRES_RETURN(detail::is_floating_point_v, Float, decimal64_t&);

--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -180,6 +180,10 @@ public:
     #endif
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast128_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast128_t(long double val) noexcept = delete;
+    #endif
+
     friend constexpr auto direct_init_d128(significand_type significand, exponent_type exponent, bool sign) noexcept -> decimal_fast128_t;
 
     // Classification functions

--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -344,7 +344,10 @@ public:
 
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;

--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -1244,10 +1244,12 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast128_t::operator double() const noexcep
     return to_float<decimal_fast128_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast128_t::operator long double() const noexcept
 {
     return to_float<decimal_fast128_t, long double>(*this);
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal_fast128_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal_fast32_t.hpp
+++ b/include/boost/decimal/decimal_fast32_t.hpp
@@ -161,6 +161,10 @@ public:
     template <typename Float, std::enable_if_t<detail::is_floating_point_v<Float>, bool> = true>
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast32_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit constexpr decimal_fast32_t(long double val) noexcept = delete;
+    #endif
+
     constexpr decimal_fast32_t(const decimal_fast32_t& val) noexcept = default;
     constexpr decimal_fast32_t(decimal_fast32_t&& val) noexcept = default;
     constexpr auto operator=(const decimal_fast32_t& val) noexcept -> decimal_fast32_t& = default;

--- a/include/boost/decimal/decimal_fast32_t.hpp
+++ b/include/boost/decimal/decimal_fast32_t.hpp
@@ -336,7 +336,10 @@ public:
     // 3.2.6 Conversion to a floating-point type
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;
@@ -1285,11 +1288,13 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast32_t::operator double() const noexcept
     return to_float<decimal_fast32_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast32_t::operator long double() const noexcept
 {
     // The precision and range of double already exceeds what decimal_fast32_t can provide
     return static_cast<long double>(to_float<decimal_fast32_t, double>(*this));
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal_fast32_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal_fast64_t.hpp
+++ b/include/boost/decimal/decimal_fast64_t.hpp
@@ -287,7 +287,9 @@ public:
 
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator float() const noexcept;
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator double() const noexcept;
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR operator long double() const noexcept;
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     explicit constexpr operator std::float16_t() const noexcept;
@@ -849,10 +851,12 @@ BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast64_t::operator double() const noexcept
     return to_float<decimal_fast64_t, double>(*this);
 }
 
+#ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast64_t::operator long double() const noexcept
 {
     return to_float<decimal_fast64_t, long double>(*this);
 }
+#endif
 
 #ifdef BOOST_DECIMAL_HAS_FLOAT16
 constexpr decimal_fast64_t::operator std::float16_t() const noexcept

--- a/include/boost/decimal/decimal_fast64_t.hpp
+++ b/include/boost/decimal/decimal_fast64_t.hpp
@@ -191,6 +191,10 @@ public:
     #endif
     explicit BOOST_DECIMAL_CXX20_CONSTEXPR decimal_fast64_t(Float val) noexcept;
 
+    #ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    explicit constexpr decimal_fast64_t(long double val) noexcept = delete;
+    #endif
+
     friend constexpr auto direct_init_d64(decimal_fast64_t::significand_type significand, decimal_fast64_t::exponent_type exponent, bool sign) noexcept -> decimal_fast64_t;
 
     // Classification functions

--- a/include/boost/decimal/detail/bit_layouts.hpp
+++ b/include/boost/decimal/detail/bit_layouts.hpp
@@ -110,6 +110,7 @@ struct IEEEl2bits
 #define BOOST_DECIMAL_LDBL_BITS 64
 
 #else // Unsupported long double representation
+#  define BOOST_DECIMAL_LDBL_BITS 0
 #  define BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
 #endif
 

--- a/include/boost/decimal/detail/ryu/ryu_generic_128.hpp
+++ b/include/boost/decimal/detail/ryu/ryu_generic_128.hpp
@@ -346,6 +346,17 @@ BOOST_DECIMAL_CXX20_CONSTEXPR auto floating_point_to_fd128<long double>(long dou
     return generic_binary_to_decimal(bits, 112, 15, false);
 }
 
+#elif BOOST_DECIMAL_LDBL_BITS == 0
+
+template <>
+BOOST_DECIMAL_CXX20_CONSTEXPR auto floating_point_to_fd128<long double>(long double val) noexcept -> floating_decimal_128
+{
+    static_assert(1==0, "Unsupported configuration");
+
+    auto bits = bit_cast<unsigned_128_type>(val);
+    return generic_binary_to_decimal(bits, 112, 15, false);
+}
+
 #endif
 
 #if defined(BOOST_DECIMAL_HAS_FLOAT128) && !defined(BOOST_DECIMAL_LDBL_IS_FLOAT128)

--- a/include/boost/decimal/detail/ryu/ryu_generic_128.hpp
+++ b/include/boost/decimal/detail/ryu/ryu_generic_128.hpp
@@ -351,7 +351,7 @@ BOOST_DECIMAL_CXX20_CONSTEXPR auto floating_point_to_fd128<long double>(long dou
 template <>
 BOOST_DECIMAL_CXX20_CONSTEXPR auto floating_point_to_fd128<long double>(long double val) noexcept -> floating_decimal_128
 {
-    static_assert(1==0, "Unsupported configuration");
+    BOOST_DECIMAL_ASSERT_MSG(1==0, "Unsupported configuration");
 
     auto bits = bit_cast<unsigned_128_type>(val);
     return generic_binary_to_decimal(bits, 112, 15, false);

--- a/test/github_issue_426.cpp
+++ b/test/github_issue_426.cpp
@@ -7,7 +7,14 @@
 #include <boost/decimal.hpp>
 #include <boost/core/lightweight_test.hpp>
 
-#if defined(__GNUC__) && __GNUC__ >= 5 && __cplusplus > 202002L
+#ifdef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+
+int main()
+{
+    return 0;
+}
+
+#elif defined(__GNUC__) && __GNUC__ >= 5 && __cplusplus > 202002L
 
 #include <complex>
 

--- a/test/roundtrip_decimal128.cpp
+++ b/test/roundtrip_decimal128.cpp
@@ -196,6 +196,8 @@ void test_roundtrip_conversion_float()
     }
 }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
+
 template <>
 void test_roundtrip_conversion_float<long double>()
 {
@@ -246,6 +248,8 @@ void test_roundtrip_conversion_float<long double>()
         }
     }
 }
+
+#endif
 
 template <typename T>
 void test_roundtrip_integer_stream()
@@ -308,6 +312,8 @@ void test_roundtrip_float_stream()
     }
 }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
+
 template <>
 void test_roundtrip_float_stream<long double>()
 {
@@ -339,6 +345,8 @@ void test_roundtrip_float_stream<long double>()
         }
     }
 }
+
+#endif
 
 void test_roundtrip_conversion_decimal32_t()
 {

--- a/test/roundtrip_decimal128.cpp
+++ b/test/roundtrip_decimal128.cpp
@@ -406,7 +406,7 @@ int main()
     test_roundtrip_float_stream<float>();
     test_roundtrip_float_stream<double>();
 
-    #if BOOST_DECIMAL_LDBL_BITS < 128
+    #if BOOST_DECIMAL_LDBL_BITS < 128 && !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
     test_conversion_from_float<long double>();
     test_conversion_to_float<long double>();
     test_roundtrip_conversion_float<long double>();

--- a/test/roundtrip_decimal128_fast.cpp
+++ b/test/roundtrip_decimal128_fast.cpp
@@ -408,7 +408,7 @@ int main()
     test_roundtrip_float_stream<float>();
     test_roundtrip_float_stream<double>();
 
-    #if BOOST_DECIMAL_LDBL_BITS < 128
+    #if BOOST_DECIMAL_LDBL_BITS < 128 && !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
     test_conversion_from_float<long double>();
     test_conversion_to_float<long double>();
     test_roundtrip_conversion_float<long double>();

--- a/test/roundtrip_decimal128_fast.cpp
+++ b/test/roundtrip_decimal128_fast.cpp
@@ -196,6 +196,8 @@ void test_roundtrip_conversion_float()
     }
 }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
+
 template <>
 void test_roundtrip_conversion_float<long double>()
 {
@@ -248,6 +250,8 @@ void test_roundtrip_conversion_float<long double>()
 
     BOOST_TEST(isnan(decimal_fast128_t(std::numeric_limits<long double>::quiet_NaN() * dist(rng))));
 }
+
+#endif
 
 template <typename T>
 void test_roundtrip_integer_stream()
@@ -310,6 +314,8 @@ void test_roundtrip_float_stream()
     }
 }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
+
 template <>
 void test_roundtrip_float_stream<long double>()
 {
@@ -341,6 +347,8 @@ void test_roundtrip_float_stream<long double>()
         }
     }
 }
+
+#endif
 
 void test_roundtrip_conversion_decimal32_t()
 {

--- a/test/roundtrip_decimal32.cpp
+++ b/test/roundtrip_decimal32.cpp
@@ -276,11 +276,9 @@ int main()
 
     test_conversion_to_float<float>();
     test_conversion_to_float<double>();
-    test_conversion_to_float<long double>();
 
     test_roundtrip_conversion_float<float>();
     test_roundtrip_conversion_float<double>();
-    test_roundtrip_conversion_float<long double>();
 
     test_roundtrip_integer_stream<int>();
     test_roundtrip_integer_stream<unsigned>();
@@ -291,7 +289,12 @@ int main()
 
     test_roundtrip_float_stream<float>();
     test_roundtrip_float_stream<double>();
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    test_conversion_to_float<long double>();
+    test_roundtrip_conversion_float<long double>();
     test_roundtrip_float_stream<long double>();
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     test_conversion_to_float<std::float16_t>();

--- a/test/roundtrip_decimal32_fast.cpp
+++ b/test/roundtrip_decimal32_fast.cpp
@@ -283,11 +283,9 @@ int main()
 
     test_conversion_to_float<float>();
     test_conversion_to_float<double>();
-    test_conversion_to_float<long double>();
 
     test_roundtrip_conversion_float<float>();
     test_roundtrip_conversion_float<double>();
-    test_roundtrip_conversion_float<long double>();
 
     test_roundtrip_integer_stream<int>();
     test_roundtrip_integer_stream<unsigned>();
@@ -298,7 +296,12 @@ int main()
 
     test_roundtrip_float_stream<float>();
     test_roundtrip_float_stream<double>();
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    test_conversion_to_float<long double>();
+    test_roundtrip_conversion_float<long double>();
     test_roundtrip_float_stream<long double>();
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     test_conversion_to_float<std::float16_t>();

--- a/test/roundtrip_decimal64.cpp
+++ b/test/roundtrip_decimal64.cpp
@@ -294,15 +294,12 @@ int main()
 
     test_conversion_from_float<float>();
     test_conversion_from_float<double>();
-    test_conversion_from_float<long double>();
 
     test_conversion_to_float<float>();
     test_conversion_to_float<double>();
-    test_conversion_to_float<long double>();
 
     test_roundtrip_conversion_float<float>();
     test_roundtrip_conversion_float<double>();
-    test_roundtrip_conversion_float<long double>();
 
     test_roundtrip_integer_stream<int>();
     test_roundtrip_integer_stream<unsigned>();
@@ -313,7 +310,13 @@ int main()
 
     test_roundtrip_float_stream<float>();
     test_roundtrip_float_stream<double>();
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    test_conversion_from_float<long double>();
+    test_conversion_to_float<long double>();
+    test_roundtrip_conversion_float<long double>();
     test_roundtrip_float_stream<long double>();
+    #endif
 
     #ifdef BOOST_DECIMAL_HAS_FLOAT16
     test_conversion_to_float<std::float16_t>();

--- a/test/test_acosh.cpp
+++ b/test/test_acosh.cpp
@@ -226,8 +226,8 @@ auto main() -> int
     local::test_acosh
     (
       static_cast<std::int32_t>(INT32_C(16) * INT32_C(262144)),
-      1.0L + static_cast<long double>(std::numeric_limits<boost::decimal::decimal32_t>::epsilon()) * 10.0L,
-      1.0L + static_cast<long double>(std::numeric_limits<boost::decimal::decimal32_t>::epsilon()) * 100.0L
+      1.0L + static_cast<double>(std::numeric_limits<boost::decimal::decimal32_t>::epsilon()) * 10.0L,
+      1.0L + static_cast<double>(std::numeric_limits<boost::decimal::decimal32_t>::epsilon()) * 100.0L
     );
 
   const auto result_tiny_is_ok   = local::test_acosh(static_cast<std::int32_t>(INT32_C(4096)), 1.001L, 1.1L);

--- a/test/test_asinh.cpp
+++ b/test/test_asinh.cpp
@@ -67,7 +67,7 @@ namespace local
     return result_is_ok;
   }
 
-  auto test_asinh(const std::int32_t tol_factor, const bool negate, const long double range_lo, const long double range_hi) -> bool
+  auto test_asinh(const std::int32_t tol_factor, const bool negate, const float range_lo, const float range_hi) -> bool
   {
     using decimal_type = boost::decimal::decimal32_t;
 
@@ -230,8 +230,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(16) * INT32_C(262144)),
       false,
-      static_cast<long double>(fourth_root_epsilon) / 40.0L,
-      static_cast<long double>(fourth_root_epsilon) * 40.0L
+      static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 40.0L),
+      static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 40.0L)
     );
 
   const auto result_tiny_is_ok       = local::test_asinh(static_cast<std::int32_t>(INT32_C(4096)), false, 1.001L, 1.1L);

--- a/test/test_asinh.cpp
+++ b/test/test_asinh.cpp
@@ -67,7 +67,7 @@ namespace local
     return result_is_ok;
   }
 
-  auto test_asinh(const std::int32_t tol_factor, const bool negate, const float range_lo, const float range_hi) -> bool
+  auto test_asinh(const std::int32_t tol_factor, const bool negate, const double range_lo, const double range_hi) -> bool
   {
     using decimal_type = boost::decimal::decimal32_t;
 
@@ -234,11 +234,11 @@ auto main() -> int
       static_cast<float>(static_cast<double>(fourth_root_epsilon) * 40.0)
     );
 
-  const auto result_tiny_is_ok       = local::test_asinh(static_cast<std::int32_t>(INT32_C(4096)), false, 1.001L, 1.1L);
-  const auto result_small_is_ok      = local::test_asinh(static_cast<std::int32_t>(INT32_C(96)),   false, 0.1L, 1.59L);
-  const auto result_medium_is_ok     = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   false, 1.59L, 10.1L);
-  const auto result_medium_neg_is_ok = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   true,  1.59L, 10.1L);
-  const auto result_large_is_ok      = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   false, 1.0E+01L, 1.0E+19L);
+  const auto result_tiny_is_ok       = local::test_asinh(static_cast<std::int32_t>(INT32_C(4096)), false, 1.001, 1.1);
+  const auto result_small_is_ok      = local::test_asinh(static_cast<std::int32_t>(INT32_C(96)),   false, 0.1, 1.59);
+  const auto result_medium_is_ok     = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   false, 1.59, 10.1);
+  const auto result_medium_neg_is_ok = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   true,  1.59, 10.1);
+  const auto result_large_is_ok      = local::test_asinh(static_cast<std::int32_t>(INT32_C(48)),   false, 1.0E+01, 1.0E+19);
 
   BOOST_TEST(result_eps_is_ok);
   BOOST_TEST(result_tiny_is_ok);

--- a/test/test_asinh.cpp
+++ b/test/test_asinh.cpp
@@ -230,8 +230,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(16) * INT32_C(262144)),
       false,
-      static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 40.0L),
-      static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 40.0L)
+      static_cast<float>(static_cast<double>(fourth_root_epsilon) / 40.0),
+      static_cast<float>(static_cast<double>(fourth_root_epsilon) * 40.0)
     );
 
   const auto result_tiny_is_ok       = local::test_asinh(static_cast<std::int32_t>(INT32_C(4096)), false, 1.001L, 1.1L);

--- a/test/test_atanh.cpp
+++ b/test/test_atanh.cpp
@@ -68,7 +68,7 @@ namespace local
     return result_is_ok;
   }
 
-  auto test_atanh(const std::int32_t tol_factor, const bool negate, const float range_lo, const float range_hi) -> bool
+  auto test_atanh(const std::int32_t tol_factor, const bool negate, const double range_lo, const double range_hi) -> bool
   {
     using decimal_type = boost::decimal::decimal32_t;
 
@@ -244,9 +244,9 @@ auto main() -> int
       static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<double>(fourth_root_epsilon) / 32.0L)))
     );
 
-  const auto result_tiny_is_ok       = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.001L, 0.1L);
-  const auto result_medium_is_ok     = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), true,  0.1L, 0.9L);
-  const auto result_medium_neg_is_ok = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.1L, 0.9L);
+  const auto result_tiny_is_ok       = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.001, 0.1);
+  const auto result_medium_is_ok     = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), true,  0.1, 0.9);
+  const auto result_medium_neg_is_ok = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.1, 0.9);
 
   BOOST_TEST(result_eps_is_ok);
   BOOST_TEST(result_eps_near_one_is_ok);

--- a/test/test_atanh.cpp
+++ b/test/test_atanh.cpp
@@ -68,7 +68,7 @@ namespace local
     return result_is_ok;
   }
 
-  auto test_atanh(const std::int32_t tol_factor, const bool negate, const long double range_lo, const long double range_hi) -> bool
+  auto test_atanh(const std::int32_t tol_factor, const bool negate, const float range_lo, const float range_hi) -> bool
   {
     using decimal_type = boost::decimal::decimal32_t;
 
@@ -231,8 +231,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(128)),
       false,
-      static_cast<long double>(fourth_root_epsilon) / 32.0L,
-      static_cast<long double>(fourth_root_epsilon) * 32.0L
+      static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 32.0L),
+      static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 32.0L)
     );
 
   const auto result_eps_near_one_is_ok =
@@ -240,8 +240,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(256)),
       false,
-      static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 32.0L)),
-      static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 32.0L))
+      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 32.0L))),
+      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 32.0L)))
     );
 
   const auto result_tiny_is_ok       = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.001L, 0.1L);

--- a/test/test_atanh.cpp
+++ b/test/test_atanh.cpp
@@ -231,8 +231,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(128)),
       false,
-      static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 32.0L),
-      static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 32.0L)
+      static_cast<float>(static_cast<double>(fourth_root_epsilon) / 32.0),
+      static_cast<float>(static_cast<double>(fourth_root_epsilon) * 32.0)
     );
 
   const auto result_eps_near_one_is_ok =
@@ -240,8 +240,8 @@ auto main() -> int
     (
       static_cast<std::int32_t>(INT32_C(256)),
       false,
-      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) * 32.0L))),
-      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<long double>(fourth_root_epsilon) / 32.0L)))
+      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<double>(fourth_root_epsilon) * 32.0L))),
+      static_cast<float>(static_cast<long double>( static_cast<float>(1.0L) - static_cast<float>(static_cast<double>(fourth_root_epsilon) / 32.0L)))
     );
 
   const auto result_tiny_is_ok       = local::test_atanh(static_cast<std::int32_t>(INT32_C(96)), false, 0.001L, 0.1L);

--- a/test/test_cmath.cpp
+++ b/test/test_cmath.cpp
@@ -1523,16 +1523,16 @@ int main()
     test_llround<decimal_fast64_t>();
 
     test_nextafter<decimal32_t>();
-    test_nexttoward<decimal32_t>();
-
     test_nextafter<decimal_fast32_t>();
-    test_nexttoward<decimal_fast32_t>();
-
     test_nextafter<decimal64_t>();
-    test_nexttoward<decimal64_t>();
-
     test_nextafter<decimal_fast64_t>();
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
+    test_nexttoward<decimal32_t>();
+    test_nexttoward<decimal_fast32_t>();
+    test_nexttoward<decimal64_t>();
     test_nexttoward<decimal_fast64_t>();
+    #endif
 
     test_pow<decimal32_t>();
     test_pow<decimal_fast32_t>();

--- a/test/test_decimal32_fast_basis.cpp
+++ b/test/test_decimal32_fast_basis.cpp
@@ -446,7 +446,7 @@ int main()
     test_construct_from_float<float>();
     test_construct_from_float<double>();
 
-    #if BOOST_DECIMAL_LDBL_BITS != 128
+    #if BOOST_DECIMAL_LDBL_BITS != 128 && !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
     test_construct_from_float<long double>();
     #endif
 

--- a/test/test_decimal64_fast_basis.cpp
+++ b/test/test_decimal64_fast_basis.cpp
@@ -413,7 +413,9 @@ int main()
 
     test_construct_from_float<float>();
     test_construct_from_float<double>();
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     test_construct_from_float<long double>();
+    #endif
     #if defined(BOOST_DECIMAL_HAS_FLOAT128) && (!defined(__clang_major__) || __clang_major__ >= 13)
     test_construct_from_float<__float128>();
     #endif

--- a/test/test_edges_and_behave.cpp
+++ b/test/test_edges_and_behave.cpp
@@ -306,7 +306,7 @@ namespace local
 
       const decimal_type c = a + b;
 
-      const auto result_prec_add_is_ok = (c == static_cast<decimal_type>(123456.8L));
+      const auto result_prec_add_is_ok = (c == static_cast<decimal_type>(123456.8));
 
       BOOST_TEST(result_prec_add_is_ok);
 

--- a/test/test_edges_and_behave.cpp
+++ b/test/test_edges_and_behave.cpp
@@ -86,7 +86,10 @@ namespace local
 
       const auto local_nan_to_construct_f  = decimal_type { std::numeric_limits<float>::quiet_NaN() * static_cast<float>(dist(gen)) };
       const auto local_nan_to_construct_d  = decimal_type { std::numeric_limits<double>::quiet_NaN() * static_cast<double>(dist(gen)) };
+
+      #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
       const auto local_nan_to_construct_ld = decimal_type { std::numeric_limits<long double>::quiet_NaN() * static_cast<long double>(dist(gen)) };
+      #endif
 
       const auto result_nan_construct_is_ok =
         (

--- a/test/test_edges_and_behave.cpp
+++ b/test/test_edges_and_behave.cpp
@@ -95,7 +95,9 @@ namespace local
         (
              isnan(local_nan_to_construct_f)
           && isnan(local_nan_to_construct_d)
+          #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
           && isnan(local_nan_to_construct_ld)
+          #endif
         );
 
       BOOST_TEST(result_nan_construct_is_ok);
@@ -105,7 +107,7 @@ namespace local
       {
         const auto sum_nan_01 = local_nan_to_construct_f + 1;
         const auto sum_nan_02 = local_nan_to_construct_f + decimal_type { 2, 0 };
-        const auto sum_nan_03 = local_nan_to_construct_f + decimal_type { 3.0L };
+        const auto sum_nan_03 = local_nan_to_construct_f + decimal_type { 3.0 };
 
         const auto result_sum_nan_is_ok = (isnan(sum_nan_01) && isnan(sum_nan_02) && isnan(sum_nan_03));
 
@@ -117,7 +119,7 @@ namespace local
       {
         const auto dif_nan_01 = local_nan_to_construct_f - 1;
         const auto dif_nan_02 = local_nan_to_construct_f - decimal_type { 2, 0 };
-        const auto dif_nan_03 = local_nan_to_construct_f - decimal_type { 3.0L };
+        const auto dif_nan_03 = local_nan_to_construct_f - decimal_type { 3.0 };
 
         const auto result_dif_nan_is_ok = (isnan(dif_nan_01) && isnan(dif_nan_02) && isnan(dif_nan_03));
 
@@ -320,7 +322,7 @@ namespace local
 
       const decimal_type c = a + b;
 
-      const auto result_prec_add_vary_is_ok = (c > decimal_type(123456.709876543L));
+      const auto result_prec_add_vary_is_ok = (c > decimal_type(123456.709876543));
 
       BOOST_TEST(result_prec_add_vary_is_ok);
 

--- a/test/test_edges_and_behave.cpp
+++ b/test/test_edges_and_behave.cpp
@@ -514,5 +514,5 @@ auto my_one () -> boost::decimal::decimal32_t& { static boost::decimal::decimal3
 auto my_inf () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_inf = std::numeric_limits<boost::decimal::decimal32_t>::infinity(); return val_inf; }
 auto my_nan () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_nan = std::numeric_limits<boost::decimal::decimal32_t>::quiet_NaN(); return val_nan; }
 auto my_pi  () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_pi  = boost::decimal::numbers::pi_v<boost::decimal::decimal32_t>; return val_pi; }
-auto my_a   () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_a { 1.234567e5L }; return val_a; }
-auto my_b   () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_b { 9.876543e-2L }; return val_b; }
+auto my_a   () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_a { 1.234567e5 }; return val_a; }
+auto my_b   () -> boost::decimal::decimal32_t& { static boost::decimal::decimal32_t val_b { 9.876543e-2 }; return val_b; }

--- a/test/test_erf.cpp
+++ b/test/test_erf.cpp
@@ -1136,7 +1136,7 @@ int main()
     test_erfc<decimal32_t>();
     test_erfc<decimal64_t>();
 
-    #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH) && BOOST_DECIMAL_LDBL_BITS != 128 && !defined(__i386__) && !defined(_WIN32)
+    #if !defined(BOOST_DECIMAL_REDUCE_TEST_DEPTH) && BOOST_DECIMAL_LDBL_BITS != 128 && !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE) && !defined(__i386__) && !defined(_WIN32)
     test_erf<decimal128_t>();
     test_erfc<decimal128_t>();
     #endif

--- a/test/test_erf.cpp
+++ b/test/test_erf.cpp
@@ -220,6 +220,7 @@ void test_erf()
     BOOST_TEST_EQ(erf(T{120}), T{1} * dist(rng));
 }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
 template <>
 void test_erf<decimal128_t>()
 {
@@ -457,6 +458,8 @@ void test_erf<decimal128_t>()
     BOOST_TEST_EQ(erf(decimal128_t{120}), decimal128_t{1} * dist(rng));
 }
 
+#endif
+
 template <typename T>
 void test_erfc()
 {
@@ -637,6 +640,8 @@ void test_erfc()
     // Underflow case
     BOOST_TEST_EQ(erfc(T{120}), T{0} * dist(rng));
 }
+
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
 
 template <>
 void test_erfc<decimal128_t>()
@@ -874,6 +879,8 @@ void test_erfc<decimal128_t>()
     // Underflow case
     BOOST_TEST_EQ(erfc(decimal128_t{120}), decimal128_t{0} * dist(rng));
 }
+
+#endif
 
 int main()
 {

--- a/test/test_float_conversion.cpp
+++ b/test/test_float_conversion.cpp
@@ -343,7 +343,10 @@ int main()
     test_compute_float80_128();
     test_generic_binary_to_decimal<float>();
     test_generic_binary_to_decimal<double>();
+
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     test_generic_binary_to_decimal<long double>();
+    #endif
 
     test_parser();
     test_hex_integer();

--- a/test/test_frexp_ldexp.cpp
+++ b/test/test_frexp_ldexp.cpp
@@ -175,7 +175,7 @@ namespace local
   }
 
   template<typename FloatingPointType>
-  auto test_frexp_ldexp_exact_impl(long double f_in, long double fr_ctrl, int nr_ctrl) -> bool
+  auto test_frexp_ldexp_exact_impl(double f_in, double fr_ctrl, int nr_ctrl) -> bool
   {
     using decimal_type = boost::decimal::decimal32_t;
 
@@ -210,9 +210,9 @@ namespace local
     // 7.625L, 0.953125L, 3
     auto result_frexp_ldexp_exact_is_ok = true;
 
-    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(+7.625L, +0.953125L,  3) && result_frexp_ldexp_exact_is_ok);
-    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(+0.125L, +0.5L,      -2) && result_frexp_ldexp_exact_is_ok);
-    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(-0.125L, -0.5L,      -2) && result_frexp_ldexp_exact_is_ok);
+    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(+7.625, +0.953125,  3) && result_frexp_ldexp_exact_is_ok);
+    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(+0.125, +0.5,      -2) && result_frexp_ldexp_exact_is_ok);
+    result_frexp_ldexp_exact_is_ok = (test_frexp_ldexp_exact_impl<float>(-0.125, -0.5,      -2) && result_frexp_ldexp_exact_is_ok);
 
     return result_frexp_ldexp_exact_is_ok;
   }

--- a/test/test_frexp_ldexp.cpp
+++ b/test/test_frexp_ldexp.cpp
@@ -262,10 +262,10 @@ namespace local
     auto result_is_ok = true;
 
     {
-      auto ldexp_dec = ldexp(static_cast<decimal_type>(0.0L), 0);
+      auto ldexp_dec = ldexp(static_cast<decimal_type>(0.0), 0);
       auto result_zero_is_ok = (ldexp_dec == 0);
 
-      ldexp_dec = ldexp(static_cast<decimal_type>(0.0L), 3);
+      ldexp_dec = ldexp(static_cast<decimal_type>(0.0), 3);
       result_zero_is_ok = ((ldexp_dec == 0) && result_zero_is_ok);
 
       result_is_ok = (result_zero_is_ok && result_is_ok);

--- a/test/test_lgamma.cpp
+++ b/test/test_lgamma.cpp
@@ -116,7 +116,7 @@ namespace local
   }
 
   template<typename DecimalType, typename FloatType>
-  auto test_lgamma(const int tol_factor, const long double range_lo, const long double range_hi) -> bool
+  auto test_lgamma(const int tol_factor, const float range_lo, const float range_hi) -> bool
   {
     using decimal_type = DecimalType;
     using float_type   = FloatType;
@@ -173,6 +173,8 @@ namespace local
 
     return result_is_ok;
   }
+
+  #if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
 
   auto test_lgamma_neg32(const int tol_factor) -> bool
   {
@@ -235,6 +237,8 @@ namespace local
 
     return result_is_ok;
   }
+
+  #endif
 
   template<typename DecimalType, typename FloatType>
   auto test_lgamma_edge() -> bool
@@ -510,6 +514,7 @@ auto main() -> int
     result_is_ok = (result_lgamma_is_ok && result_is_ok);
   }
 
+  #if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
   {
     const auto result_neg32_is_ok = local::test_lgamma_neg32(2048);
 
@@ -517,6 +522,7 @@ auto main() -> int
 
     result_is_ok = (result_neg32_is_ok && result_is_ok);
   }
+  #endif
 
   {
     using decimal_type = boost::decimal::decimal32_t;

--- a/test/test_lgamma.cpp
+++ b/test/test_lgamma.cpp
@@ -530,11 +530,13 @@ auto main() -> int
   }
 
   {
+    #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
     const auto result_lgamma128_is_ok   = local::test_lgamma_128(4096);
 
     BOOST_TEST(result_lgamma128_is_ok);
 
     result_is_ok = (result_lgamma128_is_ok && result_is_ok);
+    #endif
   }
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);

--- a/test/test_lgamma.cpp
+++ b/test/test_lgamma.cpp
@@ -116,7 +116,7 @@ namespace local
   }
 
   template<typename DecimalType, typename FloatType>
-  auto test_lgamma(const int tol_factor, const float range_lo, const float range_hi) -> bool
+  auto test_lgamma(const int tol_factor, const double range_lo, const double range_hi) -> bool
   {
     using decimal_type = DecimalType;
     using float_type   = FloatType;
@@ -452,7 +452,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal32_t;
     using float_type   = float;
 
-    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 0.01L, 0.9L);
+    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 0.01, 0.9);
 
     BOOST_TEST(result_lgamma_is_ok);
 
@@ -463,7 +463,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal32_t;
     using float_type   = float;
 
-    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 1.1L, 1.9L);
+    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 1.1, 1.9);
 
     BOOST_TEST(result_lgamma_is_ok);
 
@@ -474,7 +474,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal32_t;
     using float_type   = float;
 
-    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 2.1L, 123.4L);
+    const auto result_lgamma_is_ok   = local::test_lgamma<decimal_type, float_type>(512, 2.1, 123.4);
 
     BOOST_TEST(result_lgamma_is_ok);
 
@@ -485,7 +485,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal64_t;
     using float_type   = double;
 
-    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 0.01L, 0.9L);
+    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 0.01, 0.9);
 
     BOOST_TEST(result_lgamma_is_ok);
 
@@ -496,7 +496,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal64_t;
     using float_type   = double;
 
-    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 1.1L, 1.9L);
+    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 1.1, 1.9);
 
     BOOST_TEST(result_lgamma_is_ok);
 
@@ -507,7 +507,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal64_t;
     using float_type   = double;
 
-    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 2.1L, 123.4L);
+    const auto result_lgamma_is_ok = local::test_lgamma<decimal_type, float_type>(4096, 2.1, 123.4);
 
     BOOST_TEST(result_lgamma_is_ok);
 

--- a/test/test_tgamma.cpp
+++ b/test/test_tgamma.cpp
@@ -84,7 +84,7 @@ namespace local
   }
 
   template<typename DecimalType, typename FloatType>
-  auto test_tgamma(const int tol_factor, const float range_lo, const float range_hi) -> bool
+  auto test_tgamma(const int tol_factor, const double range_lo, const double range_hi) -> bool
   {
     using decimal_type = DecimalType;
     using float_type   = FloatType;
@@ -573,7 +573,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal32_t;
     using float_type   = float;
 
-    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 0.01L, 0.9L);
+    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 0.01, 0.9);
 
     BOOST_TEST(result_tgamma_is_ok);
 
@@ -584,7 +584,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal32_t;
     using float_type   = float;
 
-    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 2.1L, 23.4L);
+    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 2.1, 23.4);
 
     BOOST_TEST(result_tgamma_is_ok);
 
@@ -595,7 +595,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal_fast32_t;
     using float_type   = float;
 
-    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 2.1L, 23.4L);
+    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(768, 2.1, 23.4);
 
     BOOST_TEST(result_tgamma_is_ok);
 
@@ -606,7 +606,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal64_t;
     using float_type   = double;
 
-    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(4096, 0.001L, 0.9L);
+    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(4096, 0.001, 0.9);
 
     BOOST_TEST(result_tgamma_is_ok);
 
@@ -617,7 +617,7 @@ auto main() -> int
     using decimal_type = boost::decimal::decimal64_t;
     using float_type   = double;
 
-    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(4096, 2.1L, 78.9L);
+    const auto result_tgamma_is_ok   = local::test_tgamma<decimal_type, float_type>(4096, 2.1, 78.9);
 
     BOOST_TEST(result_tgamma_is_ok);
 

--- a/test/test_tgamma.cpp
+++ b/test/test_tgamma.cpp
@@ -665,6 +665,7 @@ auto main() -> int
     result_is_ok = (result_tgamma64_is_ok && result_is_ok);
   }
 
+  #ifndef BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE
   {
     const auto result_tgamma128_lo_is_ok   = local::test_tgamma_128_lo<boost::decimal::decimal128_t>(4096);
     const auto result_tgamma128_hi_is_ok   = local::test_tgamma_128_hi<boost::decimal::decimal128_t>(0x30'000);
@@ -684,6 +685,7 @@ auto main() -> int
 
     result_is_ok = (result_tgamma128_lo_is_ok && result_tgamma128_hi_is_ok && result_is_ok);
   }
+  #endif
 
   result_is_ok = ((boost::report_errors() == 0) && result_is_ok);
 

--- a/test/test_tgamma.cpp
+++ b/test/test_tgamma.cpp
@@ -84,7 +84,7 @@ namespace local
   }
 
   template<typename DecimalType, typename FloatType>
-  auto test_tgamma(const int tol_factor, const long double range_lo, const long double range_hi) -> bool
+  auto test_tgamma(const int tol_factor, const float range_lo, const float range_hi) -> bool
   {
     using decimal_type = DecimalType;
     using float_type   = FloatType;
@@ -142,6 +142,7 @@ namespace local
     return result_is_ok;
   }
 
+#if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
   auto test_tgamma_neg32(const int tol_factor) -> bool
   {
     // Table[N[Gamma[-23/100 - n], 32], {n, 1, 7, 1}]
@@ -196,6 +197,7 @@ namespace local
 
     return result_is_ok;
   }
+#endif
 
   auto test_tgamma_small_ui32() -> bool
   {
@@ -622,6 +624,7 @@ auto main() -> int
     result_is_ok = (result_tgamma_is_ok && result_is_ok);
   }
 
+  #if !defined(BOOST_DECIMAL_UNSUPPORTED_LONG_DOUBLE)
   {
     const auto result_neg32_is_ok = local::test_tgamma_neg32(768);
 
@@ -629,6 +632,7 @@ auto main() -> int
 
     result_is_ok = (result_neg32_is_ok && result_is_ok);
   }
+  #endif
 
   {
     const auto result_ui32_is_ok = local::test_tgamma_small_ui32();


### PR DESCRIPTION
Since this platform has an unsupported long double configuration we need to delete those constructors and conversion functions. Also fix the tests