### PR TITLE
Drone: llvm apt installation

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -37,7 +37,9 @@ local linux_pipeline(name, image, environment, packages = "", sources = [], arch
             commands:
             [
                 'set -e',
-                'wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -',
+                'echo $DRONE_STAGE_MACHINE',
+                'uname -a',
+                'curl -sSL --retry 5 https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm-snapshot.gpg',
             ] +
             (if sources != [] then [ ('apt-add-repository "' + source + '"') for source in sources ] else []) +
             (if packages != "" then [ 'apt-get update', 'apt-get -y install ' + packages ] else []) +
@@ -68,6 +70,9 @@ local macos_pipeline(name, environment, xcode_version = "12.2", osx_version = "c
             environment: environment + { "DEVELOPER_DIR": "/Applications/Xcode-" + xcode_version + ".app/Contents/Developer" },
             commands:
             [
+                'echo $DRONE_STAGE_MACHINE',
+                'sw_vers',
+                'uname -a',
                 'export LIBRARY=' + library,
                 './.drone/drone.sh',
             ]
@@ -94,6 +99,7 @@ local windows_pipeline(name, image, environment, arch = "amd64") =
             environment: environment,
             commands:
             [
+                'echo $env:DRONE_STAGE_MACHINE',
                 'cmd /C .drone\\\\drone.bat ' + library,
             ]
         }

--- a/.drone/drone.bat
+++ b/.drone/drone.bat
@@ -7,8 +7,6 @@
 set LIBRARY=%1
 set DRONE_BUILD_DIR=%CD%
 
-echo $env:DRONE_STAGE_MACHINE
-
 set BOOST_BRANCH=develop
 if "%DRONE_BRANCH%" == "master" set BOOST_BRANCH=master
 cd ..

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -6,8 +6,6 @@
 
 set -ex
 export PATH=~/.local/bin:/usr/local/bin:$PATH
-uname -a
-echo $DRONE_STAGE_MACHINE
 
 DRONE_BUILD_DIR=$(pwd)
 


### PR DESCRIPTION
- `apt-key` is deprecated
- `curl` will retry on more conditions than `wget`
- move debugging output $DRONE_STAGE_MACHINE to as early as possible in the script

If this goes well and tests are passing, then it's worthwhile to copy over to any other repos also.  

