### PR TITLE
Rework sqrt cbrt

### DIFF
--- a/include/boost/decimal/detail/cmath/cbrt.hpp
+++ b/include/boost/decimal/detail/cmath/cbrt.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 - 2024 Matt Borland
+// Copyright 2023 - 2026 Matt Borland
 // Copyright 2023 - 2026 Christopher Kormanyos
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt

--- a/include/boost/decimal/detail/cmath/sqrt.hpp
+++ b/include/boost/decimal/detail/cmath/sqrt.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 - 2024 Matt Borland
+// Copyright 2023 - 2026 Matt Borland
 // Copyright 2023 - 2026 Christopher Kormanyos
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt

--- a/test/test_cbrt.cpp
+++ b/test/test_cbrt.cpp
@@ -1,7 +1,10 @@
-// Copyright 2023 - 2024 Matt Borland
-// Copyright 2023 - 2026 Christopher Kormanyos
+// Copyright 2024 - 2026 Matt Borland
+// Copyright 2024 - 2026 Christopher Kormanyos
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
+
+#include "testing_config.hpp"
+#include <boost/decimal.hpp>
 
 #if defined(__clang__)
 #  pragma clang diagnostic push
@@ -10,10 +13,6 @@
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
-
-#include "testing_config.hpp"
-
-#include <boost/decimal.hpp>
 
 #include <boost/core/lightweight_test.hpp>
 

--- a/test/test_sqrt.cpp
+++ b/test/test_sqrt.cpp
@@ -1,7 +1,16 @@
-// Copyright 2023 - 2024 Matt Borland
-// Copyright 2023 - 2026 Christopher Kormanyos
+// Copyright 2024 - 2026 Matt Borland
+// Copyright 2024 - 2026 Christopher Kormanyos
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
+
+#include "testing_config.hpp"
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+
+#include <boost/decimal.hpp>
 
 #if defined(__clang__)
 #  pragma clang diagnostic push
@@ -11,17 +20,7 @@
 #  pragma GCC diagnostic ignored "-Wfloat-equal"
 #endif
 
-#include "testing_config.hpp"
-
-#include <boost/decimal.hpp>
-
 #include <boost/core/lightweight_test.hpp>
-
-#include <chrono>
-#include <iomanip>
-#include <iostream>
-#include <limits>
-#include <random>
 
 template<typename DecimalType> auto my_zero() -> DecimalType& { using decimal_type = DecimalType; static decimal_type val_zero { 0, 0 }; return val_zero; }
 template<typename DecimalType> auto my_one () -> DecimalType& { using decimal_type = DecimalType; static decimal_type val_one  { 1, 0 }; return val_one; }


### PR DESCRIPTION
This PR reworks and improves the existing `sqrt` and `cbrt` impls.

- For `sqrt` reduce the argument further to $1/16 < x {\leq} 1/4$ and run the Pade approximation at $1/8$.
- For `cbrt` reduce the argument further to $1/64 < x {\leq} 1/8$ and run the Pade approximation at $1/16$.
- Reduce the loops of Newton iterations on both to $2,3,4$, down from $3,4,5$.
- Decrease the $128$-bit tolerance of `cbrt` to expected value.
- Do some sync-up of the imps `sqrt` and `cbrt`.

This is one that I've had planned for a while. I think it's about as good as I'm going to get it with the current technology.

Note that these calculations are still slow and could _DEFINITELY_ use efficiency improvements, for instance with a better initial guess.

 