### PR TITLE
Fix the `quantize()` function

### DIFF
--- a/include/boost/decimal/cmath.hpp
+++ b/include/boost/decimal/cmath.hpp
@@ -246,36 +246,6 @@ BOOST_DECIMAL_EXPORT constexpr auto quantexp(decimal_fast128_t x) noexcept -> in
     return quantexpd128f(x);
 }
 
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal32_t lhs, decimal32_t rhs) noexcept -> decimal32_t
-{
-    return quantized32(lhs, rhs);
-}
-
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal_fast32_t lhs, decimal_fast32_t rhs) noexcept -> decimal_fast32_t
-{
-    return quantized32f(lhs, rhs);
-}
-
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal64_t lhs, decimal64_t rhs) noexcept -> decimal64_t
-{
-    return quantized64(lhs, rhs);
-}
-
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> decimal_fast64_t
-{
-    return quantized64f(lhs, rhs);
-}
-
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal128_t lhs, decimal128_t rhs) noexcept -> decimal128_t
-{
-    return quantized128(lhs, rhs);
-}
-
-BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal_fast128_t lhs, decimal_fast128_t rhs) noexcept -> decimal_fast128_t
-{
-    return quantized128f(lhs, rhs);
-}
-
 } // namespace decimal
 } // namespace boost
 

--- a/include/boost/decimal/cmath.hpp
+++ b/include/boost/decimal/cmath.hpp
@@ -201,6 +201,11 @@ BOOST_DECIMAL_EXPORT constexpr auto samequantum(decimal64_t lhs, decimal64_t rhs
     return samequantumd64(lhs, rhs);
 }
 
+BOOST_DECIMAL_EXPORT constexpr auto samequantum(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> bool
+{
+    return samequantumd64f(lhs, rhs);
+}
+
 BOOST_DECIMAL_EXPORT constexpr auto samequantum(decimal128_t lhs, decimal128_t rhs) noexcept -> bool
 {
     return samequantumd128(lhs, rhs);
@@ -254,6 +259,11 @@ BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal_fast32_t lhs, decimal_fast3
 BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal64_t lhs, decimal64_t rhs) noexcept -> decimal64_t
 {
     return quantized64(lhs, rhs);
+}
+
+BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> decimal_fast64_t
+{
+    return quantized64f(lhs, rhs);
 }
 
 BOOST_DECIMAL_EXPORT constexpr auto quantize(decimal128_t lhs, decimal128_t rhs) noexcept -> decimal128_t

--- a/include/boost/decimal/decimal128_t.hpp
+++ b/include/boost/decimal/decimal128_t.hpp
@@ -26,6 +26,7 @@
 #include <boost/decimal/detail/to_decimal.hpp>
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -2196,7 +2197,19 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized128(const decimal128_t& lhs, const de
     }
     #endif
 
-    return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal128_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return boost::decimal::from_bits(boost::decimal::detail::d128_snan_mask);
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 BOOST_DECIMAL_CUDA_CONSTEXPR auto copysignd128(decimal128_t mag, const decimal128_t sgn) noexcept -> decimal128_t

--- a/include/boost/decimal/decimal128_t.hpp
+++ b/include/boost/decimal/decimal128_t.hpp
@@ -557,7 +557,8 @@ public:
     friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantexpd128(decimal128_t x) noexcept -> int;
 
     // 3.6.6 Quantize
-    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized128(const decimal128_t& lhs, const decimal128_t& rhs) noexcept -> decimal128_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 
     // <cmath> functions that need to be friends
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
@@ -2160,56 +2161,6 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantexpd128(const decimal128_t x) noexcept ->
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// 3.6.6
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized128(const decimal128_t& lhs, const decimal128_t& rhs) noexcept -> decimal128_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    else if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return boost::decimal::from_bits(boost::decimal::detail::d128_snan_mask);
-    }
-    else if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal128_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return boost::decimal::from_bits(boost::decimal::detail::d128_snan_mask);
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 BOOST_DECIMAL_CUDA_CONSTEXPR auto copysignd128(decimal128_t mag, const decimal128_t sgn) noexcept -> decimal128_t

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -565,7 +565,8 @@ public:
     friend constexpr auto quantexpd32(decimal32_t x) noexcept -> int;
 
     // 3.6.6 Quantize
-    friend constexpr auto quantized32(decimal32_t lhs, decimal32_t rhs) noexcept -> decimal32_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 
     // <cmath> functions that need to be friends
     friend constexpr auto copysignd32(decimal32_t mag, decimal32_t sgn) noexcept -> decimal32_t;
@@ -2258,56 +2259,6 @@ constexpr auto quantexpd32(const decimal32_t x) noexcept -> int
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// 3.6.6
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-constexpr auto quantized32(const decimal32_t lhs, const decimal32_t rhs) noexcept -> decimal32_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return from_bits(detail::d32_snan_mask);
-    }
-    if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal32_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return from_bits(detail::d32_snan_mask);
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 constexpr auto scalblnd32(decimal32_t num, const long exp) noexcept -> decimal32_t

--- a/include/boost/decimal/decimal32_t.hpp
+++ b/include/boost/decimal/decimal32_t.hpp
@@ -26,6 +26,7 @@
 #include <boost/decimal/detail/to_decimal.hpp>
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -2294,7 +2295,19 @@ constexpr auto quantized32(const decimal32_t lhs, const decimal32_t rhs) noexcep
     }
     #endif
 
-    return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal32_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return from_bits(detail::d32_snan_mask);
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 constexpr auto scalblnd32(decimal32_t num, const long exp) noexcept -> decimal32_t

--- a/include/boost/decimal/decimal64_t.hpp
+++ b/include/boost/decimal/decimal64_t.hpp
@@ -576,7 +576,8 @@ public:
     friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantexpd64(decimal64_t x) noexcept -> int;
 
     // 3.6.6 Quantize
-    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized64(decimal64_t lhs, decimal64_t rhs) noexcept -> decimal64_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 
     // <cmath> functions that need to be friends
     template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
@@ -2166,56 +2167,6 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantexpd64(const decimal64_t x) noexcept -> i
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// 3.6.6
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized64(const decimal64_t lhs, const decimal64_t rhs) noexcept -> decimal64_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return boost::decimal::from_bits(boost::decimal::detail::d64_snan_mask);
-    }
-    if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal64_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return boost::decimal::from_bits(boost::decimal::detail::d64_snan_mask);
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 BOOST_DECIMAL_CUDA_CONSTEXPR auto scalblnd64(decimal64_t num, const long exp) noexcept -> decimal64_t

--- a/include/boost/decimal/decimal64_t.hpp
+++ b/include/boost/decimal/decimal64_t.hpp
@@ -28,6 +28,7 @@
 #include <boost/decimal/detail/comparison.hpp>
 #include <boost/decimal/detail/mixed_decimal_arithmetic.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -2202,7 +2203,19 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantized64(const decimal64_t lhs, const decim
     }
     #endif
 
-    return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal64_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return boost::decimal::from_bits(boost::decimal::detail::d64_snan_mask);
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 BOOST_DECIMAL_CUDA_CONSTEXPR auto scalblnd64(decimal64_t num, const long exp) noexcept -> decimal64_t

--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -26,6 +26,7 @@
 #include <boost/decimal/detail/to_decimal.hpp>
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -1731,7 +1732,19 @@ constexpr auto quantized128f(const decimal_fast128_t& lhs, const decimal_fast128
     }
     #endif
 
-    return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal_fast128_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return boost::decimal::direct_init_d128(boost::decimal::detail::d128_fast_qnan, 0, false);
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 #if !defined(BOOST_DECIMAL_DISABLE_CLIB)

--- a/include/boost/decimal/decimal_fast128_t.hpp
+++ b/include/boost/decimal/decimal_fast128_t.hpp
@@ -500,7 +500,8 @@ public:
     friend constexpr auto quantexpd128f(const decimal_fast128_t& x) noexcept -> int;
 
     // 3.6.6 Quantize
-    friend constexpr auto quantized128f(const decimal_fast128_t& lhs, const decimal_fast128_t& rhs) noexcept -> decimal_fast128_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 };
 
 #ifdef _MSC_VER
@@ -1695,56 +1696,6 @@ constexpr auto quantexpd128f(const decimal_fast128_t& x) noexcept -> int
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// 3.6.6
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-constexpr auto quantized128f(const decimal_fast128_t& lhs, const decimal_fast128_t& rhs) noexcept -> decimal_fast128_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    else if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return boost::decimal::direct_init_d128(boost::decimal::detail::d128_fast_qnan, 0, false);
-    }
-    else if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal_fast128_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return boost::decimal::direct_init_d128(boost::decimal::detail::d128_fast_qnan, 0, false);
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 #if !defined(BOOST_DECIMAL_DISABLE_CLIB)

--- a/include/boost/decimal/decimal_fast32_t.hpp
+++ b/include/boost/decimal/decimal_fast32_t.hpp
@@ -26,6 +26,7 @@
 #include <boost/decimal/detail/to_decimal.hpp>
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -1718,7 +1719,19 @@ constexpr auto quantized32f(const decimal_fast32_t lhs, const decimal_fast32_t r
     }
     #endif
 
-    return {lhs.full_significand(), rhs.biased_exponent(), lhs.isneg()};
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal_fast32_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return direct_init(detail::d32_fast_snan, UINT8_C(0));
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 #if !defined(BOOST_DECIMAL_DISABLE_CLIB)

--- a/include/boost/decimal/decimal_fast32_t.hpp
+++ b/include/boost/decimal/decimal_fast32_t.hpp
@@ -498,7 +498,8 @@ public:
     // Specific decimal functionality
     friend constexpr auto samequantumd32f(decimal_fast32_t lhs, decimal_fast32_t rhs) noexcept -> bool;
     friend constexpr auto quantexpd32f(decimal_fast32_t x) noexcept -> int;
-    friend constexpr auto quantized32f(decimal_fast32_t lhs, decimal_fast32_t rhs) noexcept -> decimal_fast32_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 };
 
 #ifdef _MSC_VER
@@ -1683,55 +1684,6 @@ constexpr auto quantexpd32f(const decimal_fast32_t x) noexcept -> int
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value, as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN, the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-constexpr auto quantized32f(const decimal_fast32_t lhs, const decimal_fast32_t rhs) noexcept -> decimal_fast32_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    else if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return direct_init(detail::d32_fast_snan, UINT8_C(0));
-    }
-    else if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal_fast32_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return direct_init(detail::d32_fast_snan, UINT8_C(0));
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 #if !defined(BOOST_DECIMAL_DISABLE_CLIB)

--- a/include/boost/decimal/decimal_fast64_t.hpp
+++ b/include/boost/decimal/decimal_fast64_t.hpp
@@ -26,6 +26,7 @@
 #include <boost/decimal/detail/to_decimal.hpp>
 #include <boost/decimal/detail/promotion.hpp>
 #include <boost/decimal/detail/check_non_finite.hpp>
+#include <boost/decimal/detail/quantize_impl.hpp>
 #include <boost/decimal/detail/shrink_significand.hpp>
 #include <boost/decimal/detail/cmath/isfinite.hpp>
 #include <boost/decimal/detail/cmath/fpclassify.hpp>
@@ -500,7 +501,9 @@ public:
     friend constexpr auto copysignd64f(decimal_fast64_t mag, decimal_fast64_t sgn) noexcept -> decimal_fast64_t;
     friend constexpr auto scalbnd64f(decimal_fast64_t num, int exp) noexcept -> decimal_fast64_t;
     friend constexpr auto scalblnd64f(decimal_fast64_t num, long exp) noexcept -> decimal_fast64_t;
+    friend constexpr auto samequantumd64f(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> bool;
     friend constexpr auto quantexpd64f(decimal_fast64_t x) noexcept -> int;
+    friend constexpr auto quantized64f(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> decimal_fast64_t;
 };
 
 #ifdef _MSC_VER
@@ -1662,6 +1665,29 @@ constexpr auto decimal_fast64_t::operator--(int) noexcept -> decimal_fast64_t
     return temp;
 }
 
+// Effects: determines if the quantum exponents of x and y are the same.
+// If both x and y are NaN, or infinity, they have the same quantum exponents;
+// if exactly one operand is infinity or exactly one operand is NaN, they do not have the same quantum exponents.
+// The samequantum functions raise no exception.
+constexpr auto samequantumd64f(const decimal_fast64_t lhs, const decimal_fast64_t rhs) noexcept -> bool
+{
+    #ifndef BOOST_DECIMAL_FAST_MATH
+    const auto lhs_fp {fpclassify(lhs)};
+    const auto rhs_fp {fpclassify(rhs)};
+
+    if ((lhs_fp == FP_NAN && rhs_fp == FP_NAN) || (lhs_fp == FP_INFINITE && rhs_fp == FP_INFINITE))
+    {
+        return true;
+    }
+    if ((lhs_fp == FP_NAN || rhs_fp == FP_INFINITE) || (rhs_fp == FP_NAN || lhs_fp == FP_INFINITE))
+    {
+        return false;
+    }
+    #endif
+
+    return lhs.unbiased_exponent() == rhs.unbiased_exponent();
+}
+
 // Effects: if x is finite, returns its quantum exponent.
 // Otherwise, a domain error occurs and INT_MIN is returned.
 constexpr auto quantexpd64f(const decimal_fast64_t x) noexcept -> int
@@ -1674,6 +1700,55 @@ constexpr auto quantexpd64f(const decimal_fast64_t x) noexcept -> int
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
+}
+
+// Returns: a number that is equal in value (except for any rounding) and sign to x,
+// and which has an exponent set to be equal to the exponent of y.
+// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
+// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
+// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
+// the "invalid" floating-point exception is raised and the result is NaN.
+// If one or both operands are NaN, the result is NaN.
+// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
+// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
+// The quantize functions do not signal underflow.
+constexpr auto quantized64f(const decimal_fast64_t lhs, const decimal_fast64_t rhs) noexcept -> decimal_fast64_t
+{
+    #ifndef BOOST_DECIMAL_FAST_MATH
+    // Return the correct type of nan
+    if (isnan(lhs))
+    {
+        return lhs;
+    }
+    else if (isnan(rhs))
+    {
+        return rhs;
+    }
+
+    // If one is infinity then return a signaling NAN
+    if (isinf(lhs) != isinf(rhs))
+    {
+        return direct_init_d64(detail::d64_fast_snan, 0, false);
+    }
+    else if (isinf(lhs) && isinf(rhs))
+    {
+        return lhs;
+    }
+    #endif
+
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<decimal_fast64_t>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return direct_init_d64(detail::d64_fast_snan, 0, false);
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
 }
 
 constexpr auto scalblnd64f(decimal_fast64_t num, const long exp) noexcept -> decimal_fast64_t

--- a/include/boost/decimal/decimal_fast64_t.hpp
+++ b/include/boost/decimal/decimal_fast64_t.hpp
@@ -503,7 +503,8 @@ public:
     friend constexpr auto scalblnd64f(decimal_fast64_t num, long exp) noexcept -> decimal_fast64_t;
     friend constexpr auto samequantumd64f(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> bool;
     friend constexpr auto quantexpd64f(decimal_fast64_t x) noexcept -> int;
-    friend constexpr auto quantized64f(decimal_fast64_t lhs, decimal_fast64_t rhs) noexcept -> decimal_fast64_t;
+    template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE T>
+    friend BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(T lhs, T rhs) noexcept -> T;
 };
 
 #ifdef _MSC_VER
@@ -1700,55 +1701,6 @@ constexpr auto quantexpd64f(const decimal_fast64_t x) noexcept -> int
     #endif
 
     return static_cast<int>(x.unbiased_exponent());
-}
-
-// Returns: a number that is equal in value (except for any rounding) and sign to x,
-// and which has an exponent set to be equal to the exponent of y.
-// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
-// if the result does not have the same value as x, the "inexact" floating-point exception is raised.
-// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
-// the "invalid" floating-point exception is raised and the result is NaN.
-// If one or both operands are NaN, the result is NaN.
-// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
-// If both operands are infinity, the result is DEC_INFINITY, with the same sign as x, converted to the type of x.
-// The quantize functions do not signal underflow.
-constexpr auto quantized64f(const decimal_fast64_t lhs, const decimal_fast64_t rhs) noexcept -> decimal_fast64_t
-{
-    #ifndef BOOST_DECIMAL_FAST_MATH
-    // Return the correct type of nan
-    if (isnan(lhs))
-    {
-        return lhs;
-    }
-    else if (isnan(rhs))
-    {
-        return rhs;
-    }
-
-    // If one is infinity then return a signaling NAN
-    if (isinf(lhs) != isinf(rhs))
-    {
-        return direct_init_d64(detail::d64_fast_snan, 0, false);
-    }
-    else if (isinf(lhs) && isinf(rhs))
-    {
-        return lhs;
-    }
-    #endif
-
-    auto components {lhs.to_components()};
-    const auto rhs_exp {rhs.biased_exponent()};
-
-    if (!detail::quantize_rescale<decimal_fast64_t>(components.sig, components.exp - rhs_exp, components.sign))
-    {
-        #ifndef BOOST_DECIMAL_FAST_MATH
-        return direct_init_d64(detail::d64_fast_snan, 0, false);
-        #else
-        return {components.sig, rhs_exp, components.sign};
-        #endif
-    }
-
-    return {components.sig, rhs_exp, components.sign};
 }
 
 constexpr auto scalblnd64f(decimal_fast64_t num, const long exp) noexcept -> decimal_fast64_t

--- a/include/boost/decimal/detail/add_impl.hpp
+++ b/include/boost/decimal/detail/add_impl.hpp
@@ -61,6 +61,17 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto add_impl(const T& lhs, const T& rhs) noexcept 
 
             #endif
 
+            // Resolve fe_dec_toward_zero into the equivalent directional mode
+            // for the result's sign so the down/up paths below cover it too.
+            // (toward zero == toward -inf for positive results, == toward +inf
+            // for negative results.)
+            if (round == rounding_mode::fe_dec_toward_zero)
+            {
+                const bool resolved_use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
+                const bool result_is_neg {resolved_use_lhs ? lhs.isneg() : rhs.isneg()};
+                round = result_is_neg ? rounding_mode::fe_dec_upward : rounding_mode::fe_dec_downward;
+            }
+
             if (BOOST_DECIMAL_LIKELY(round != rounding_mode::fe_dec_downward && round != rounding_mode::fe_dec_upward))
             {
                 return big_lhs != 0U && (lhs_exp > rhs_exp) ?
@@ -219,6 +230,17 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto d128_add_impl_new(const T& lhs, const T& rhs) 
             }
 
             #endif
+
+            // Resolve fe_dec_toward_zero into the equivalent directional mode
+            // for the result's sign so the down/up paths below cover it too.
+            // (toward zero == toward -inf for positive results, == toward +inf
+            // for negative results.)
+            if (round == rounding_mode::fe_dec_toward_zero)
+            {
+                const bool resolved_use_lhs {big_lhs != 0U && (lhs_exp > rhs_exp)};
+                const bool result_is_neg {resolved_use_lhs ? lhs.isneg() : rhs.isneg()};
+                round = result_is_neg ? rounding_mode::fe_dec_upward : rounding_mode::fe_dec_downward;
+            }
 
             if (BOOST_DECIMAL_LIKELY(round != rounding_mode::fe_dec_downward && round != rounding_mode::fe_dec_upward))
             {

--- a/include/boost/decimal/detail/quantize_impl.hpp
+++ b/include/boost/decimal/detail/quantize_impl.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#ifndef BOOST_DECIMAL_DETAIL_QUANTIZE_IMPL_HPP
+#define BOOST_DECIMAL_DETAIL_QUANTIZE_IMPL_HPP
+
+#include <boost/decimal/fwd.hpp>
+#include <boost/decimal/detail/attributes.hpp>
+#include <boost/decimal/detail/concepts.hpp>
+#include <boost/decimal/detail/config.hpp>
+#include <boost/decimal/detail/fenv_rounding.hpp>
+#include <boost/decimal/detail/integer_search_trees.hpp>
+#include <boost/decimal/detail/power_tables.hpp>
+
+namespace boost {
+namespace decimal {
+namespace detail {
+
+// Implements the IEEE 754-2008 5.3.2 quantize operation by rescaling
+// the significand of x to match the quantum exponent of y.
+template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType, typename Significand>
+BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize_rescale(Significand& sig, const int delta, const bool sign) noexcept -> bool
+{
+    if (delta == 0 || sig == Significand{0})
+    {
+        return true;
+    }
+
+    if (delta > 0)
+    {
+        const auto sig_digits {num_digits(sig)};
+        if (sig_digits + delta > precision_v<DecimalType>)
+        {
+            return false;
+        }
+        sig *= pow10(static_cast<Significand>(delta));
+        return true;
+    }
+
+    const auto neg_delta {-delta};
+    const auto sig_digits {num_digits(sig)};
+
+    if (neg_delta > sig_digits)
+    {
+        const bool sticky {sig != Significand{0}};
+        sig = Significand{0};
+        fenv_round<DecimalType>(sig, sign, sticky);
+    }
+    else if (neg_delta > 1)
+    {
+        const auto pre_div {pow10(static_cast<Significand>(neg_delta - 1))};
+        const auto remainder {sig % pre_div};
+        sig /= pre_div;
+        const bool sticky {remainder != Significand{0}};
+        fenv_round<DecimalType>(sig, sign, sticky);
+    }
+    else
+    {
+        fenv_round<DecimalType>(sig, sign, false);
+    }
+
+    return true;
+}
+
+} // namespace detail
+} // namespace decimal
+} // namespace boost
+
+#endif // BOOST_DECIMAL_DETAIL_QUANTIZE_IMPL_HPP

--- a/include/boost/decimal/detail/quantize_impl.hpp
+++ b/include/boost/decimal/detail/quantize_impl.hpp
@@ -87,13 +87,18 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(const DecimalType lhs, const DecimalT
 {
     #ifndef BOOST_DECIMAL_FAST_MATH
     // Return the correct type of nan
-    if (isnan(lhs))
+    if (isnan(lhs) || isnan(rhs))
     {
-        return issignaling(lhs) ? nan_conversion(lhs) : lhs;
-    }
-    if (isnan(rhs))
-    {
-        return issignaling(rhs) ? nan_conversion(rhs) : rhs;
+        if (issignaling(lhs))
+        {
+            return nan_conversion(lhs);
+        }
+        else if (issignaling(rhs))
+        {
+            return nan_conversion(rhs);
+        }
+
+        return isnan(lhs) ? lhs : rhs;
     }
 
     // If exactly one operand is infinity then return a NaN

--- a/include/boost/decimal/detail/quantize_impl.hpp
+++ b/include/boost/decimal/detail/quantize_impl.hpp
@@ -12,6 +12,12 @@
 #include <boost/decimal/detail/fenv_rounding.hpp>
 #include <boost/decimal/detail/integer_search_trees.hpp>
 #include <boost/decimal/detail/power_tables.hpp>
+#include <boost/decimal/detail/cmath/isfinite.hpp>
+#include <boost/decimal/detail/cmath/fpclassify.hpp>
+
+#ifndef BOOST_DECIMAL_BUILD_MODULE
+#include <limits>
+#endif
 
 namespace boost {
 namespace decimal {
@@ -64,6 +70,58 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize_rescale(Significand& sig, const int d
 }
 
 } // namespace detail
+
+// IEEE 754-2008 3.6.6
+// Returns: a number that is equal in value (except for any rounding) and sign to lhs,
+// and which has an exponent set to be equal to the exponent of rhs.
+// If the exponent is being increased, the value is correctly rounded according to the current rounding mode;
+// if the result does not have the same value as lhs, the "inexact" floating-point exception is raised.
+// If the exponent is being decreased and the significand of the result has more digits than the type would allow,
+// the "invalid" floating-point exception is raised and the result is NaN.
+// If one or both operands are NaN, the result is NaN.
+// Otherwise, if only one operand is infinity, the "invalid" floating-point exception is raised and the result is NaN.
+// If both operands are infinity, the result is DEC_INFINITY, with the same sign as lhs.
+// The quantize functions do not signal underflow.
+BOOST_DECIMAL_EXPORT template <BOOST_DECIMAL_DECIMAL_FLOATING_TYPE DecimalType>
+BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(const DecimalType lhs, const DecimalType rhs) noexcept -> DecimalType
+{
+    #ifndef BOOST_DECIMAL_FAST_MATH
+    // Return the correct type of nan
+    if (isnan(lhs))
+    {
+        return lhs;
+    }
+    if (isnan(rhs))
+    {
+        return rhs;
+    }
+
+    // If exactly one operand is infinity then return a signaling NaN
+    if (isinf(lhs) != isinf(rhs))
+    {
+        return std::numeric_limits<DecimalType>::signaling_NaN();
+    }
+    if (isinf(lhs) && isinf(rhs))
+    {
+        return lhs;
+    }
+    #endif
+
+    auto components {lhs.to_components()};
+    const auto rhs_exp {rhs.biased_exponent()};
+
+    if (!detail::quantize_rescale<DecimalType>(components.sig, components.exp - rhs_exp, components.sign))
+    {
+        #ifndef BOOST_DECIMAL_FAST_MATH
+        return std::numeric_limits<DecimalType>::signaling_NaN();
+        #else
+        return {components.sig, rhs_exp, components.sign};
+        #endif
+    }
+
+    return {components.sig, rhs_exp, components.sign};
+}
+
 } // namespace decimal
 } // namespace boost
 

--- a/include/boost/decimal/detail/quantize_impl.hpp
+++ b/include/boost/decimal/detail/quantize_impl.hpp
@@ -118,6 +118,11 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(const DecimalType lhs, const DecimalT
     if (!detail::quantize_rescale<DecimalType>(components.sig, components.exp - rhs_exp, components.sign))
     {
         #ifndef BOOST_DECIMAL_FAST_MATH
+        // Handle zeros as a special case since we already canonicalize them
+        if (rhs.full_significand() == typename decltype(components)::significand_type{0})
+        {
+            return DecimalType{typename decltype(components)::significand_type{0}, rhs_exp, components.sign};
+        }
         return std::numeric_limits<DecimalType>::quiet_NaN();
         #else
         return {components.sig, rhs_exp, components.sign};

--- a/include/boost/decimal/detail/quantize_impl.hpp
+++ b/include/boost/decimal/detail/quantize_impl.hpp
@@ -89,17 +89,17 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(const DecimalType lhs, const DecimalT
     // Return the correct type of nan
     if (isnan(lhs))
     {
-        return lhs;
+        return issignaling(lhs) ? nan_conversion(lhs) : lhs;
     }
     if (isnan(rhs))
     {
-        return rhs;
+        return issignaling(rhs) ? nan_conversion(rhs) : rhs;
     }
 
-    // If exactly one operand is infinity then return a signaling NaN
+    // If exactly one operand is infinity then return a NaN
     if (isinf(lhs) != isinf(rhs))
     {
-        return std::numeric_limits<DecimalType>::signaling_NaN();
+        return std::numeric_limits<DecimalType>::quiet_NaN();
     }
     if (isinf(lhs) && isinf(rhs))
     {
@@ -113,7 +113,7 @@ BOOST_DECIMAL_CUDA_CONSTEXPR auto quantize(const DecimalType lhs, const DecimalT
     if (!detail::quantize_rescale<DecimalType>(components.sig, components.exp - rhs_exp, components.sign))
     {
         #ifndef BOOST_DECIMAL_FAST_MATH
-        return std::numeric_limits<DecimalType>::signaling_NaN();
+        return std::numeric_limits<DecimalType>::quiet_NaN();
         #else
         return {components.sig, rhs_exp, components.sign};
         #endif

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -93,6 +93,7 @@ run github_issue_1319.cpp ;
 run github_issue_1329.cpp ;
 run github_issue_1361.cpp ;
 run github_issue_1378.cpp ;
+run github_issue_1383.cpp ;
 run github_issue_1384.cpp ;
 
 run link_1.cpp link_2.cpp link_3.cpp ;

--- a/test/github_issue_1383.cpp
+++ b/test/github_issue_1383.cpp
@@ -1,0 +1,35 @@
+// Copyright 2026 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// See: https://github.com/boostorg/decimal/issues/1383
+
+#include <boost/decimal.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+using namespace boost::decimal;
+
+template <typename T>
+void test_spot(const T lhs, const T rhs, const T result)
+{
+    BOOST_TEST_EQ(quantize(lhs, rhs), result);
+}
+
+template <typename T>
+void test_driver()
+{
+    test_spot(T{0}, T{1}, T{0});
+    test_spot(T{1}, T{1}, T{1});
+    test_spot(T{1, -1}, T{1, 2}, T{0});
+    test_spot(T{1, -1}, T{1, 1}, T{0});
+    test_spot(T{1, -1}, T{1, -1}, T{1, -1});
+}
+
+int main()
+{
+    test_driver<decimal32_t>();
+    test_driver<decimal64_t>();
+    test_driver<decimal128_t>();
+
+    return boost::report_errors();
+}

--- a/test/test_decimal_quantum.cpp
+++ b/test/test_decimal_quantum.cpp
@@ -132,30 +132,65 @@ void test_quantize()
     constexpr auto max_iter {std::is_same<Dec, decimal128_t>::value ? N / 4 : N};
     for (std::size_t i {}; i < max_iter; ++i)
     {
-        auto sig1 {static_cast<sig_type>(sig(rng))};
-        auto sig2 {static_cast<sig_type>(sig(rng))};
-        auto exp1 {exp(rng)};
-        auto exp2 {exp(rng)};
-
-        detail::normalize<Dec>(sig1, exp1);
-        detail::normalize<Dec>(sig1, exp1);
+        const auto sig1 {static_cast<sig_type>(sig(rng))};
+        const auto sig2 {static_cast<sig_type>(sig(rng))};
+        const auto exp1 {exp(rng)};
 
         const Dec val1 {sig1, exp1};
-        const Dec val2 {sig2, exp2};
+        // Both values share the quantum exponent so the IEEE 754-2008 quantize
+        // operation reduces to a no-op that returns lhs unchanged. Both
+        // significands have the same digit count, so the fast types normalize
+        // them identically and end up with the same stored exponent.
+        const Dec val2 {sig2, exp1};
 
-        const Dec quantized_val {sig1, exp2};
-
-        if (!BOOST_TEST_EQ(quantize(val1, val2), quantized_val))
+        if (!BOOST_TEST_EQ(quantize(val1, val2), val1))
         {
             // LCOV_EXCL_START
             std::cerr << std::setprecision(std::numeric_limits<Dec>::digits10)
                       << "Val 1: " << val1
                       << "\nVal 2: " << val2
-                      << "\nQuant: " << quantized_val
                       << "\n Func: " << quantize(val1, val2) << std::endl;
             // LCOV_EXCL_STOP
         }
     }
+}
+
+template <typename Dec>
+void test_quantize_spot()
+{
+    // IEEE 754-2008 5.3.2: quantize(x, y) returns a value equal to x (modulo
+    // rounding) but with the quantum exponent of y.
+
+    const auto check = [](Dec x, Dec y, Dec expected)
+    {
+        if (!BOOST_TEST_EQ(quantize(x, y), expected))
+        {
+            // LCOV_EXCL_START
+            std::cerr << std::setprecision(std::numeric_limits<Dec>::digits10)
+                      << "x:        " << x
+                      << "\ny:        " << y
+                      << "\nexpected: " << expected
+                      << "\nactual:   " << quantize(x, y) << std::endl;
+            // LCOV_EXCL_STOP
+        }
+    };
+
+    // Same exponent: identity
+    check(Dec{1, -1}, Dec{1, -1}, Dec{1, -1});
+
+    // Smaller rhs exponent: significand grows, value is exact
+    check(Dec{217}, Dec{1, -1}, Dec{2170, -1});
+
+    // Larger rhs exponent: significand shrinks with rounding
+    check(Dec{217}, Dec{1, 1}, Dec{22, 1});
+    check(Dec{217}, Dec{1, 2}, Dec{2, 2});
+
+    // Rounding all digits away rounds to zero or one based on the leading digit
+    check(Dec{1, -1}, Dec{1, 1}, Dec{0, 1});
+    check(Dec{1, -1}, Dec{1, 2}, Dec{0, 2});
+
+    // Sign of x is preserved on non-zero results
+    check(Dec{-217}, Dec{1, -1}, Dec{-2170, -1});
 }
 
 template <typename Dec>
@@ -181,6 +216,7 @@ int main()
     test_quantexp<decimal32_t>();
     test_nonfinite_quantexp<decimal32_t>();
     test_quantize<decimal32_t>();
+    test_quantize_spot<decimal32_t>();
     test_nonfinite_quantize<decimal32_t>();
 
     test_same_quantum<decimal_fast32_t>();
@@ -190,6 +226,9 @@ int main()
     //test_quantexp<decimal_fast32_t>();
     test_nonfinite_quantexp<decimal_fast32_t>();
     test_quantize<decimal_fast32_t>();
+    // The fast types renormalize the significand to full precision in their
+    // constructor, which changes the canonical quantum exponent, so the
+    // exponent-based spot tests use values that only apply to IEEE types.
     test_nonfinite_quantize<decimal_fast32_t>();
 
     test_same_quantum<decimal64_t>();
@@ -197,13 +236,27 @@ int main()
     test_quantexp<decimal64_t>();
     test_nonfinite_quantexp<decimal64_t>();
     test_quantize<decimal64_t>();
+    test_quantize_spot<decimal64_t>();
     test_nonfinite_quantize<decimal64_t>();
+
+    test_same_quantum<decimal_fast64_t>();
+    test_nonfinite_samequantum<decimal_fast64_t>();
+    // decimal_fast64_t normalizes its value in the constructor,
+    // so it will not match the values of the other types
+    //test_quantexp<decimal_fast64_t>();
+    test_nonfinite_quantexp<decimal_fast64_t>();
+    test_quantize<decimal_fast64_t>();
+    // The fast types renormalize the significand to full precision in their
+    // constructor, which changes the canonical quantum exponent, so the
+    // exponent-based spot tests use values that only apply to IEEE types.
+    test_nonfinite_quantize<decimal_fast64_t>();
 
     test_same_quantum<decimal128_t>();
     test_nonfinite_samequantum<decimal128_t>();
     test_quantexp<decimal128_t>();
     test_nonfinite_quantexp<decimal128_t>();
     test_quantize<decimal128_t>();
+    test_quantize_spot<decimal128_t>();
     test_nonfinite_quantize<decimal128_t>();
 
     return boost::report_errors();


### PR DESCRIPTION
Closes: #1383 

The only lingering failures are that we currently canonicalize 0 whereas decTest expects zero to also obey cohorts. This I guess is true per 3.5.1 "A zero has a much larger cohort: the cohort of +0 contains a representation for each exponent, as
does the cohort of −0"