### PR TITLE
Docs: edit_url setting

### DIFF
--- a/doc/decimal-playbook.yml
+++ b/doc/decimal-playbook.yml
@@ -5,7 +5,7 @@ content:
   sources:
     - url: ..
       start_path: doc
-      branches: develop
+      edit_url: 'https://github.com/boostorg/decimal/edit/develop/{path}'
 output:
   dir: html
 ui:


### PR DESCRIPTION
After feedback from Ruben (boostorg/redis) the `edit_url` setting seems more appropriate than `branches`. It is exactly aimed at the issue.